### PR TITLE
fix(appshell): assemble full layout, add AircraftPhoto and StatusBar

### DIFF
--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -5,6 +5,11 @@ import { useAdsbPoller } from './lib/adsb'
 import SkyChart from './components/SkyChart'
 import WeatherPanel from './components/WeatherPanel'
 import FirstRun from './components/FirstRun'
+import IdentityPanel from './components/IdentityPanel/IdentityPanel'
+import RoutePanel from './components/RoutePanel'
+import TransponderPanel from './components/TransponderPanel'
+import HistoryPanel from './components/HistoryPanel/HistoryPanel'
+import StatusBar from './components/StatusBar/StatusBar'
 
 export default function App() {
   const configured = localStorage.getItem('skywatcher-configured') === 'true'
@@ -17,25 +22,83 @@ export default function App() {
   return <AppShell />
 }
 
+function formatDistance(m) {
+  if (m == null) return '—'
+  return m >= 1000 ? `${(m / 1000).toFixed(1)} km` : `${Math.round(m)} m`
+}
+
 function AppShell() {
   useAdsbPoller()
 
-  const { visibleAircraft, pollingStatus } = useContext(AircraftContext)
-  const { theme } = useContext(SettingsContext)
+  const { visibleAircraft, currentAircraft, pollingStatus } = useContext(AircraftContext)
+  const { theme, chartVariant, updateSettings } = useContext(SettingsContext)
 
   const showWeather = visibleAircraft.length === 0 && pollingStatus === 'active'
+  const variant = chartVariant || 'classic'
 
   return (
     <div className="app" data-theme={theme === 'auto' ? undefined : theme}>
+      <StatusBar />
+
       {showWeather ? (
         <WeatherPanel />
       ) : (
-        <div style={{ width: 300, height: 300 }}>
-          <SkyChart
-            aircraft={visibleAircraft}
-            variant="classic"
-            loading={pollingStatus === 'idle'}
-          />
+        <div className="main">
+          <div className="left-pane">
+            <div className="corners-top">
+              <div />
+              <div className="chart-toggle">
+                <button
+                  className={variant === 'classic' ? 'active' : ''}
+                  onClick={() => updateSettings({ chartVariant: 'classic' })}
+                >
+                  Classic
+                </button>
+                <button
+                  className={variant === 'dome' ? 'active' : ''}
+                  onClick={() => updateSettings({ chartVariant: 'dome' })}
+                >
+                  Dome
+                </button>
+              </div>
+            </div>
+
+            <div className="chart-wrap">
+              <SkyChart
+                aircraft={visibleAircraft}
+                variant={variant}
+                loading={pollingStatus === 'idle'}
+              />
+            </div>
+
+            <div className="bearing-strip">
+              <div className="stat">
+                <div className="stat-k">AZ</div>
+                <div className="stat-v sm accent">
+                  {currentAircraft ? `${Math.round(currentAircraft.az)}°` : '—'}
+                </div>
+              </div>
+              <div className="stat">
+                <div className="stat-k">EL</div>
+                <div className="stat-v sm accent">
+                  {currentAircraft ? `${Math.round(currentAircraft.el)}°` : '—'}
+                </div>
+              </div>
+              <div className="stat">
+                <div className="stat-k">DIST</div>
+                <div className="stat-v sm">
+                  {currentAircraft ? formatDistance(currentAircraft.distance3d) : '—'}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="right-pane">
+            <IdentityPanel />
+            <RoutePanel />
+            <TransponderPanel />
+            <HistoryPanel />
+          </div>
         </div>
       )}
     </div>

--- a/www/src/components/IdentityPanel/AircraftPhoto.jsx
+++ b/www/src/components/IdentityPanel/AircraftPhoto.jsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react'
+import { fetchPhoto } from '../../lib/photos'
+
+export default function AircraftPhoto({ hex }) {
+  const [photo, setPhoto] = useState(undefined) // undefined=loading, null=empty, object=loaded
+
+  useEffect(() => {
+    if (!hex) { setPhoto(null); return }
+    setPhoto(undefined)
+    let cancelled = false
+    fetchPhoto(hex).then(result => {
+      if (!cancelled) setPhoto(result)
+    })
+    return () => { cancelled = true }
+  }, [hex])
+
+  if (photo === undefined) {
+    return <div className="photo-slot photo-slot--loading" />
+  }
+  if (photo === null) {
+    return <div className="photo-slot photo-slot--empty" />
+  }
+  return (
+    <figure className="aircraft-photo">
+      <img src={photo.src} alt={`Aircraft ${hex}`} />
+      <figcaption>
+        <a href={photo.link} target="_blank" rel="noopener noreferrer">
+          © {photo.photographer} · Planespotters.net
+        </a>
+      </figcaption>
+    </figure>
+  )
+}

--- a/www/src/components/StatusBar/StatusBar.jsx
+++ b/www/src/components/StatusBar/StatusBar.jsx
@@ -1,0 +1,90 @@
+import { useContext } from 'react'
+import { AircraftContext } from '../../contexts/AircraftContext'
+import { SettingsContext } from '../../contexts/SettingsContext'
+
+function StarIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M12 2 L14 10 L22 12 L14 14 L12 22 L10 14 L2 12 L10 10 Z" />
+    </svg>
+  )
+}
+
+function SunIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+    </svg>
+  )
+}
+
+function AutoIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 3v18" />
+    </svg>
+  )
+}
+
+function ThemeToggle() {
+  const { theme, updateSettings } = useContext(SettingsContext)
+  return (
+    <div className="theme-toggle">
+      {['auto', 'light', 'dark'].map(t => (
+        <button
+          key={t}
+          className={theme === t ? 'active' : ''}
+          onClick={() => updateSettings({ theme: t })}
+          aria-label={t}
+        >
+          {t === 'auto' ? <AutoIcon /> : t === 'light' ? <SunIcon /> : <MoonIcon />}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default function StatusBar() {
+  const { visibleAircraft, pollingStatus } = useContext(AircraftContext)
+
+  return (
+    <div className="statusbar">
+      <div className="statusbar-brand">
+        <StarIcon />
+        <span className="name serif">Skywatcher</span>
+      </div>
+
+      <div className="statusbar-center">
+        {pollingStatus === 'active' && visibleAircraft.length > 0 && (
+          <span className="live-badge">
+            <span className="live-dot" />
+            {visibleAircraft.length} AIRCRAFT VISIBLE
+          </span>
+        )}
+        {pollingStatus === 'active' && visibleAircraft.length === 0 && (
+          <span className="poll-ring">SCANNING…</span>
+        )}
+        {pollingStatus === 'idle' && (
+          <span className="poll-ring">AWAITING CONFIG</span>
+        )}
+        {pollingStatus === 'error' && (
+          <span className="poll-ring" style={{ color: 'var(--warn)' }}>RECEIVER ERROR</span>
+        )}
+      </div>
+
+      <div className="statusbar-right">
+        <ThemeToggle />
+      </div>
+    </div>
+  )
+}

--- a/www/src/components/StatusBar/index.js
+++ b/www/src/components/StatusBar/index.js
@@ -1,0 +1,1 @@
+export { default } from './StatusBar'


### PR DESCRIPTION
## Summary
- **AircraftPhoto.jsx** — loading/empty/loaded states via `fetchPhoto(hex)`, cancellation-safe effect, correct Planespotters attribution markup
- **StatusBar.jsx** — brand logo, live aircraft count badge, polling status indicator, auto/light/dark theme toggle
- **App.jsx AppShell** — full two-pane layout: `StatusBar`, left pane (chart + variant toggle + bearing strip), right pane (IdentityPanel, RoutePanel, TransponderPanel, HistoryPanel); weather empty-state preserves StatusBar

## Build verified
`cd www && npx vite build` — 51 modules, clean output, 0 errors.

## Closes
Closes #12 · Closes #13 · Closes #14

## Test plan
- [ ] App loads with full layout after first-run (not just sky chart)
- [ ] AircraftPhoto renders loading shimmer → photo or empty silhouette
- [ ] StatusBar shows live badge when aircraft visible, SCANNING when none, AWAITING CONFIG when idle
- [ ] Theme toggle cycles auto → light → dark and persists via SettingsContext
- [ ] Classic/Dome chart variant toggle works and persists
- [ ] Bearing strip shows AZ/EL/DIST for closest aircraft; dashes when none

🤖 Generated with [Claude Code](https://claude.com/claude-code)