### PR TITLE
fix(proxy): quota only on successful FA responses, add /health endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -123,12 +123,12 @@ app.get('/api/enrich/:callsign', async (req, res) => {
       headers: { 'x-apikey': apiKey },
     });
 
-    incrementQuota();
-
     if (!faRes.ok) {
       console.error(`[enrich] FlightAware returned HTTP ${faRes.status} for ${callsign}`);
       return res.status(faRes.status).json({ error: 'fa_upstream_error', status: faRes.status });
     }
+
+    incrementQuota();
 
     const faData = await faRes.json();
 
@@ -156,6 +156,12 @@ app.get('/api/enrich/:callsign', async (req, res) => {
     return res.status(502).json({ error: 'fa_fetch_failed' });
   }
 });
+
+// ─── GET /health ─────────────────────────────────────────────────────────────
+
+app.get('/health', (_req, res) => {
+  return res.json({ status: 'ok' })
+})
 
 // ─── GET /api/quota ───────────────────────────────────────────────────────────
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -160,8 +160,8 @@ app.get('/api/enrich/:callsign', async (req, res) => {
 // ─── GET /health ─────────────────────────────────────────────────────────────
 
 app.get('/health', (_req, res) => {
-  return res.json({ status: 'ok' })
-})
+  return res.json({ status: 'ok' });
+});
 
 // ─── GET /api/quota ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **Quota fix** — moved `incrementQuota()` to after `faRes.ok` check in `/api/enrich/:callsign`. Failed FlightAware responses (4xx/5xx) no longer consume the daily budget.
- **Health endpoint** — added `GET /health → { status: 'ok' }` so `Dockerfile.proxy` HEALTHCHECK succeeds instead of marking the container perpetually unhealthy.

## Diff (backend/server.js)
```diff
-    incrementQuota();
-
     if (!faRes.ok) { … return … }
+
+    incrementQuota();
```
```diff
+app.get('/health', (_req, res) => { return res.json({ status: 'ok' }) })
```

## Closes
Closes #23 · Closes #24

## Test plan
- [ ] `GET /api/quota` returns `{ used: 0, remaining: 100, limit: 100 }` on startup
- [ ] Simulating a 500 from FlightAware does not increment quota count
- [ ] `curl http://localhost:3000/health` returns `{ "status": "ok" }` with HTTP 200
- [ ] Docker container health check shows `healthy` after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)