### PR TITLE
fix(first-run): server-side config gate + setup persistence + host .env writeback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,12 @@
 # ADS-B receiver URL (e.g. dump1090/tar1090)
-ADSB_URL=http://pi.local:8080
+# If left blank, the first-run wizard will collect it and write it back here.
+ADSB_URL=
 
-# FlightAware AeroAPI key (injected server-side, never sent to browser)
+# FlightAware AeroAPI key — injected server-side, never sent to browser.
+# If left blank, the first-run wizard will collect it and write it back here.
 FLIGHTAWARE_API_KEY=
 
-# Observer location (can also be set via first-run UI)
+# Observer location — collected by first-run wizard if blank.
 OBSERVER_LAT=
 OBSERVER_LON=
 OBSERVER_ELEV=
@@ -12,3 +14,7 @@ OBSERVER_ELEV=
 # Optional overrides
 OBSTRUCTION_ANGLE=14.2
 FA_DAILY_QUOTA=100
+FA_MONTHLY_BUDGET=9.50
+
+# External port for the frontend container (default 80)
+APP_PORT=80

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import { writeFile, readFile, rename } from 'fs/promises';
+import { writeFile, readFile, rename, access, constants } from 'fs/promises';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -16,15 +16,101 @@ const FA_MONTHLY_BUDGET = parseFloat(process.env.FA_MONTHLY_BUDGET ?? '9.50');
 const FA_DAILY_SOFT_LIMIT = Math.floor(FA_DAILY_QUOTA * 0.95);
 
 const QUOTA_FILE = resolve(__dirname, 'quota.json');
+const SETUP_FILE = resolve(__dirname, 'setup.json');
+// Bind-mounted host .env — written back after first-run so Portainer shows the values
+const HOST_ENV_FILE = '/app/.env.host';
 
 // Mutable runtime config — can be updated via POST /api/setup
 const runtimeConfig = {
-  adsbUrl: process.env.ADSB_URL ?? 'http://localhost:8080',
+  adsbUrl: process.env.ADSB_URL ?? null,
   lat: process.env.OBSERVER_LAT ?? null,
   lon: process.env.OBSERVER_LON ?? null,
   elev: process.env.OBSERVER_ELEV ?? null,
   obstructionAngle: process.env.OBSTRUCTION_ANGLE ?? '14.2',
 };
+
+// ─── Setup persistence (setup.json + host .env writeback) ────────────────────
+
+async function loadSetup() {
+  try {
+    const raw = await readFile(SETUP_FILE, 'utf8');
+    const saved = JSON.parse(raw);
+    // Env vars take precedence over saved file — only fill gaps
+    if (!runtimeConfig.adsbUrl && saved.adsbUrl) runtimeConfig.adsbUrl = saved.adsbUrl;
+    if (!runtimeConfig.lat    && saved.lat)     runtimeConfig.lat = saved.lat;
+    if (!runtimeConfig.lon    && saved.lon)     runtimeConfig.lon = saved.lon;
+    if (!runtimeConfig.elev   && saved.elev)    runtimeConfig.elev = saved.elev;
+    if (saved.obstructionAngle) runtimeConfig.obstructionAngle = saved.obstructionAngle;
+    console.log('[setup] Restored config from setup.json');
+  } catch {
+    // File absent on first start — use env vars (or null)
+  }
+  // Apply default ADSB URL only if nothing was configured at all
+  if (!runtimeConfig.adsbUrl) runtimeConfig.adsbUrl = 'http://localhost:8080';
+}
+
+async function persistSetup() {
+  const tmp = `${SETUP_FILE}.tmp`;
+  try {
+    await writeFile(tmp, JSON.stringify({
+      adsbUrl: runtimeConfig.adsbUrl,
+      lat: runtimeConfig.lat,
+      lon: runtimeConfig.lon,
+      elev: runtimeConfig.elev,
+      obstructionAngle: runtimeConfig.obstructionAngle,
+    }), 'utf8');
+    await rename(tmp, SETUP_FILE);
+  } catch (err) {
+    console.error('[setup] Failed to persist setup.json:', err.message);
+  }
+}
+
+// Write collected config back to the bind-mounted host .env so Portainer reflects
+// the values. Updates existing keys in-place and appends any missing ones.
+async function writeBackHostEnv(faKey) {
+  try {
+    await access(HOST_ENV_FILE, constants.W_OK);
+  } catch {
+    console.log('[setup] Host .env not mounted or not writable — skipping writeback');
+    return;
+  }
+
+  let src = '';
+  try { src = await readFile(HOST_ENV_FILE, 'utf8'); } catch { /* new file */ }
+
+  const updates = {
+    ADSB_URL: runtimeConfig.adsbUrl,
+    OBSERVER_LAT: runtimeConfig.lat,
+    OBSERVER_LON: runtimeConfig.lon,
+    OBSERVER_ELEV: runtimeConfig.elev,
+    OBSTRUCTION_ANGLE: runtimeConfig.obstructionAngle,
+    ...(faKey ? { FLIGHTAWARE_API_KEY: faKey } : {}),
+  };
+
+  const lines = src.split('\n');
+  const seen = new Set();
+
+  const updated = lines.map(line => {
+    const m = line.match(/^([A-Z_]+)=/);
+    if (m && updates[m[1]] != null) {
+      seen.add(m[1]);
+      return `${m[1]}=${updates[m[1]]}`;
+    }
+    return line;
+  });
+
+  for (const [key, val] of Object.entries(updates)) {
+    if (!seen.has(key) && val != null) updated.push(`${key}=${val}`);
+  }
+
+  const out = updated.join('\n').replace(/\n{3,}/g, '\n\n').trim() + '\n';
+  try {
+    await writeFile(HOST_ENV_FILE, out, 'utf8');
+    console.log('[setup] Wrote config back to host .env');
+  } catch (err) {
+    console.error('[setup] Failed to write host .env:', err.message);
+  }
+}
 
 // ─── FlightAware cache (server-side, TTL 24 h) ───────────────────────────────
 
@@ -291,27 +377,30 @@ app.post('/api/setup', async (req, res) => {
     });
   }
 
-  // Update non-secret runtime config
+  // Update non-secret runtime config and persist for container restarts
   runtimeConfig.adsbUrl = adsbUrl;
   runtimeConfig.lat = String(lat);
   runtimeConfig.lon = String(lon);
   runtimeConfig.elev = String(elev);
   runtimeConfig.obstructionAngle = obstructionAngle != null ? String(obstructionAngle) : runtimeConfig.obstructionAngle;
+  await persistSetup();
 
   // Handle FA key — never log, never return
   const faKeyProvided = typeof faKey === 'string' && faKey.trim().length > 0;
+  const trimmedKey = faKeyProvided ? faKey.trim() : null;
   if (faKeyProvided) {
-    process.env.FLIGHTAWARE_API_KEY = faKey.trim();
+    process.env.FLIGHTAWARE_API_KEY = trimmedKey;
     try {
       const envPath = resolve(__dirname, '.env.local');
-      await writeFile(envPath, `FLIGHTAWARE_API_KEY=${faKey.trim()}\n`, { mode: 0o600 });
+      await writeFile(envPath, `FLIGHTAWARE_API_KEY=${trimmedKey}\n`, { mode: 0o600 });
     } catch (writeErr) {
       console.error('[setup] Failed to persist FA key to .env.local:', writeErr.message);
-      // Non-fatal — key is set in memory even if file write fails
     }
-    // Seed FA usage state now that we have a key
     pollFaUsage();
   }
+
+  // Write all collected values back to the bind-mounted host .env for Portainer visibility
+  await writeBackHostEnv(trimmedKey);
 
   return res.json({
     success: true,
@@ -328,6 +417,7 @@ app.post('/api/setup', async (req, res) => {
 
 // ─── Startup ──────────────────────────────────────────────────────────────────
 
+await loadSetup();
 await loadQuota();
 await pollFaUsage();
 setInterval(pollFaUsage, 60 * 60 * 1000);

--- a/backend/server.js
+++ b/backend/server.js
@@ -371,10 +371,24 @@ app.post('/api/setup', async (req, res) => {
   if (elev === undefined || elev === null || elev === '') missing.push('elev');
 
   if (missing.length > 0) {
-    return res.status(400).json({
-      error: 'missing_required_fields',
-      fields: missing,
-    });
+    return res.status(400).json({ error: 'missing_required_fields', fields: missing });
+  }
+
+  // Validate coordinate ranges
+  const latNum = parseFloat(lat);
+  const lonNum = parseFloat(lon);
+  const elevNum = parseFloat(elev);
+  const angleNum = obstructionAngle != null ? parseFloat(obstructionAngle) : null;
+
+  const coordErrors = [];
+  if (isNaN(latNum) || latNum < -90  || latNum > 90)    coordErrors.push('lat must be -90 to 90');
+  if (isNaN(lonNum) || lonNum < -180 || lonNum > 180)   coordErrors.push('lon must be -180 to 180');
+  if (isNaN(elevNum) || elevNum < 0  || elevNum > 50000) coordErrors.push('elev must be 0–50000 ft');
+  if (angleNum !== null && (isNaN(angleNum) || angleNum < 0 || angleNum > 90))
+    coordErrors.push('obstructionAngle must be 0–90°');
+
+  if (coordErrors.length > 0) {
+    return res.status(400).json({ error: 'invalid_fields', messages: coordErrors });
   }
 
   // Update non-secret runtime config and persist for container restarts
@@ -395,6 +409,11 @@ app.post('/api/setup', async (req, res) => {
       await writeFile(envPath, `FLIGHTAWARE_API_KEY=${trimmedKey}\n`, { mode: 0o600 });
     } catch (writeErr) {
       console.error('[setup] Failed to persist FA key to .env.local:', writeErr.message);
+      // Key is in memory for this session but won't survive a restart — tell the client
+      return res.status(507).json({
+        error: 'key_not_persisted',
+        message: 'FA key accepted but could not be saved to disk. Check container permissions.',
+      });
     }
     pollFaUsage();
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile.frontend
     container_name: skywatcher-frontend
     ports:
-      - "80:80"
+      - "${APP_PORT:-80}:80"
     depends_on:
       proxy:
         condition: service_started
@@ -31,6 +31,8 @@ services:
       - NODE_ENV=production
       - PORT=3000
       - TZ=UTC
+    volumes:
+      - ./.env:/app/.env.host
     networks:
       - skywatcher
     restart: unless-stopped

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useState, useEffect } from 'react'
 import { AircraftContext } from './contexts/AircraftContext'
 import { SettingsContext } from './contexts/SettingsContext'
 import { useAdsbPoller } from './lib/adsb'
@@ -12,11 +12,20 @@ import HistoryPanel from './components/HistoryPanel/HistoryPanel'
 import StatusBar from './components/StatusBar/StatusBar'
 
 export default function App() {
-  const configured = localStorage.getItem('skywatcher-configured') === 'true'
-  const [showFirstRun, setShowFirstRun] = useState(!configured)
+  // null = checking, true = configured, false = needs first-run
+  const [configured, setConfigured] = useState(null)
 
-  if (showFirstRun) {
-    return <FirstRun onComplete={() => setShowFirstRun(false)} />
+  useEffect(() => {
+    fetch('/api/config')
+      .then(r => r.json())
+      .then(cfg => setConfigured(Boolean(cfg.lat && cfg.lon && cfg.adsbUrl)))
+      .catch(() => setConfigured(false))
+  }, [])
+
+  if (configured === null) return null
+
+  if (!configured) {
+    return <FirstRun onComplete={() => setConfigured(true)} />
   }
 
   return <AppShell />

--- a/www/src/components/FirstRun/FirstRun.jsx
+++ b/www/src/components/FirstRun/FirstRun.jsx
@@ -278,14 +278,12 @@ export default function FirstRun({ onComplete }) {
       setFaKey('')
       setSubmitStatus('saved')
 
-      // Persist observer settings to context
       updateObserver({
         lat: parseFloat(lat),
         lon: parseFloat(lon),
         elev: parseFloat(elev),
         obstructionAngle: parseFloat(obstructionAngle),
       })
-      localStorage.setItem('skywatcher-configured', 'true')
 
       // Brief "saved" pause, then show completion screen, then fire onComplete
       setTimeout(() => {


### PR DESCRIPTION
## Summary

- **First-run gate moved server-side** — `App.jsx` now fetches `GET /api/config` on mount instead of reading `localStorage`. If `lat && lon && adsbUrl` are populated (from env vars or `setup.json`), the wizard is skipped for all browsers/devices. Closes #34.
- **`setup.json` persistence restored** — config written by the first-run wizard survives container restarts without requiring Portainer env vars to be set first. Env vars still take precedence over the saved file. (This was in `feat/fa-usage-monitor` but was dropped in the PR #33 squash.)
- **Host `.env` writeback** — after `POST /api/setup` completes, all collected values (`ADSB_URL`, `OBSERVER_*`, `OBSTRUCTION_ANGLE`, `FLIGHTAWARE_API_KEY`) are written back to the bind-mounted `/app/.env.host`. On next Portainer stack redeploy, the env vars appear pre-populated. Closes #35.
- **`APP_PORT` restored** in `docker-compose.yml` (was hardcoded `80:80` in main).
- **`.env.example` updated** — adds `FA_MONTHLY_BUDGET`, `APP_PORT`, and clarifies first-run writeback behaviour.

## Test plan

- [ ] New browser with no localStorage and no env vars → first-run wizard appears
- [ ] Complete wizard → main app loads; second browser immediately skips wizard
- [ ] Restart proxy container → `GET /api/config` still returns config (setup.json restored)
- [ ] With `OBSERVER_LAT`/`OBSERVER_LON`/`ADSB_URL` set as env vars → no wizard on any browser
- [ ] After first-run, inspect `.env` on host → values written back by proxy
- [ ] `APP_PORT=8888` in `.env` → container binds to port 8888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration settings are now persisted across application restarts.
  * FlightAware API key can be saved to the host environment file.
  * Added configurable monthly budget and external port settings.

* **Improvements**
  * First-run wizard now properly initializes all required configuration values.
  * Host port is now customizable via configuration variable (defaults to 80).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->