### PR TITLE
fix(nginx): write pid to /tmp for unprivileged nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,5 @@
+pid /tmp/nginx.pid;
+
 events { worker_connections 1024; }
 
 http {


### PR DESCRIPTION
## Summary
- Adds `pid /tmp/nginx.pid;` to `nginx/nginx.conf`
- Our custom config overrides the entire nginx config, losing the `/tmp/nginx.pid` default set by the `nginx-unprivileged` image
- Without this, nginx crashes on every start with `open() "/run/nginx.pid" failed (13: Permission denied)`

## Test plan
- [ ] Rebuild and start the frontend container on prod (`192.168.2.5:8888`)
- [ ] Confirm no `Permission denied` errors in `docker logs skywatcher-frontend`
- [ ] Confirm app is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application server configuration to manage process identification file location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->