### PR TITLE
fix(config): sync server coordinates to client settings

### DIFF
--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -28,15 +28,16 @@ export default function App() {
         // by inheriting the server's coordinates automatically.
         if (isConfigured && observer.lat === null) {
           updateObserver({
-            lat: String(cfg.lat),
-            lon: String(cfg.lon),
-            elev: String(cfg.elev),
-            obstructionAngle: String(cfg.obstructionAngle ?? '14.2'),
+            lat: parseFloat(cfg.lat),
+            lon: parseFloat(cfg.lon),
+            elev: parseFloat(cfg.elev),
+            obstructionAngle: parseFloat(cfg.obstructionAngle ?? 14.2),
           })
         }
       })
       .catch(() => setConfigured(false))
-  }, [observer.lat, updateObserver])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   if (configured === null) return null
 

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -12,15 +12,31 @@ import HistoryPanel from './components/HistoryPanel/HistoryPanel'
 import StatusBar from './components/StatusBar/StatusBar'
 
 export default function App() {
+  const { observer, updateObserver } = useContext(SettingsContext)
   // null = checking, true = configured, false = needs first-run
   const [configured, setConfigured] = useState(null)
 
   useEffect(() => {
     fetch('/api/config')
       .then(r => r.json())
-      .then(cfg => setConfigured(Boolean(cfg.lat && cfg.lon && cfg.adsbUrl)))
+      .then(cfg => {
+        const isConfigured = Boolean(cfg.lat && cfg.lon && cfg.adsbUrl)
+        setConfigured(isConfigured)
+
+        // If server is configured but local settings are empty, sync them.
+        // This handles new browser sessions (incognito, separate device)
+        // by inheriting the server's coordinates automatically.
+        if (isConfigured && observer.lat === null) {
+          updateObserver({
+            lat: String(cfg.lat),
+            lon: String(cfg.lon),
+            elev: String(cfg.elev),
+            obstructionAngle: String(cfg.obstructionAngle ?? '14.2'),
+          })
+        }
+      })
       .catch(() => setConfigured(false))
-  }, [])
+  }, [observer.lat, updateObserver])
 
   if (configured === null) return null
 

--- a/www/src/contexts/SettingsContext.jsx
+++ b/www/src/contexts/SettingsContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useEffect } from 'react'
+import { createContext, useState, useEffect, useCallback } from 'react'
 
 const STORAGE_KEY = 'skywatcher-settings'
 
@@ -35,16 +35,16 @@ export function SettingsProvider({ children }) {
     }
   }, [settings.theme])
 
-  function updateSettings(patch) {
+  const updateSettings = useCallback((patch) => {
     setSettings(prev => ({ ...prev, ...patch }))
-  }
+  }, [])
 
-  function updateObserver(patch) {
+  const updateObserver = useCallback((patch) => {
     setSettings(prev => ({
       ...prev,
       observer: { ...prev.observer, ...patch },
     }))
-  }
+  }, [])
 
   return (
     <SettingsContext.Provider value={{ ...settings, updateSettings, updateObserver }}>


### PR DESCRIPTION
## Summary
- Synchronizes server-side observer configuration (lat, lon, elev, obstructionAngle) to client-side `SettingsContext` on application initialization.
- Fixes the "AWAITING CONFIG" issue where new browser sessions (incognito, separate devices) would fail to start polling even if the server was already configured.
- Closes #47.

## Test Plan
- [x] Verified project builds successfully with `npm run build`.
- [x] Logic ensures synchronization only happens if local coordinates are missing (`observer.lat === null`) and server config is valid.