### PR TITLE
fix(mobile): landscape map clipped + remove quota reset countdown

### DIFF
--- a/skywatcher.css
+++ b/skywatcher.css
@@ -270,6 +270,15 @@ body { transition: background 0.25s var(--ease), color 0.25s var(--ease); }
   }
 }
 
+/* Landscape phones: revert to side-by-side grid so the chart fits in the viewport height */
+@media (max-width: 900px) and (orientation: landscape) {
+  .app { height: 100dvh; overflow: hidden; }
+  .main { display: grid; grid-template-columns: 1.15fr 1fr; overflow: hidden; flex: 1; height: auto; }
+  .left-pane { min-height: 0; overflow: hidden; border-right: 1px solid var(--line); border-bottom: none; }
+  .chart-wrap { flex: 1; aspect-ratio: unset; max-width: unset; min-height: 0; width: auto; margin: 0; }
+  .right-pane { overflow-y: auto; height: auto; }
+}
+
 .bearing-strip {
   display: grid; grid-template-columns: repeat(3, 1fr);
   gap: 16px;

--- a/www/src/components/StatusBar/StatusBar.jsx
+++ b/www/src/components/StatusBar/StatusBar.jsx
@@ -1,26 +1,7 @@
-import { useContext, useState, useEffect } from 'react'
+import { useContext } from 'react'
 import { AircraftContext } from '../../contexts/AircraftContext'
 import { SettingsContext } from '../../contexts/SettingsContext'
 
-function formatTimeUntil(isoString) {
-  if (!isoString) return null
-  const ms = new Date(isoString) - Date.now()
-  if (ms <= 0) return null
-  const totalMin = Math.floor(ms / 60000)
-  const h = Math.floor(totalMin / 60)
-  const m = totalMin % 60
-  return h > 0 ? `${h}h ${m}m` : `${m}m`
-}
-
-function useCountdown(isoString) {
-  const [label, setLabel] = useState(() => formatTimeUntil(isoString))
-  useEffect(() => {
-    setLabel(formatTimeUntil(isoString))
-    const id = setInterval(() => setLabel(formatTimeUntil(isoString)), 60000)
-    return () => clearInterval(id)
-  }, [isoString])
-  return label
-}
 
 function StarIcon() {
   return (
@@ -109,7 +90,6 @@ function OrientationToggle({ orientation }) {
 
 export default function StatusBar({ orientation }) {
   const { visibleAircraft, pollingStatus, quota } = useContext(AircraftContext)
-  const resetIn = useCountdown(quota?.resetsAt)
 
   return (
     <div className="statusbar">
@@ -137,7 +117,6 @@ export default function StatusBar({ orientation }) {
         {quota && (
           <span className="quota-badge">
             FA {quota.used}/{quota.softLimit ?? quota.limit}
-            {resetIn && <span className="quota-reset"> · resets {resetIn}</span>}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Landscape phones (≤900px wide) now use the desktop side-by-side grid layout so the sky chart fits within the viewport height. Previously the chart was 420px tall in a 390px viewport, cutting off 40% of the compass.
- Removed the "resets 2h 0m" quota reset countdown from the status bar (per user request).

## Root Cause
`@media (max-width: 900px)` fired for landscape phones (e.g. 844×390) because width < 900px, applying a column stack layout. The `chart-wrap` was sized at 420×420 but only 251px of viewport height was available below the header, clipping the bottom of the compass.

## Fix
Added `@media (max-width: 900px) and (orientation: landscape)` override block that reverts `.app`, `.main`, `.left-pane`, `.chart-wrap`, and `.right-pane` to the desktop grid behavior.

## Test plan
- [ ] Load on a real phone in landscape — confirm full compass is visible without scrolling
- [ ] Load on a real phone in portrait — confirm no regression (chart still shows)
- [ ] Confirm "resets Xh Ym" no longer appears in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout behavior for landscape orientation on smaller screens; adjusted grid layout, scroll handling, and component sizing.

* **Refactor**
  * Simplified quota badge display by removing the reset timer indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->