### PR TITLE
fix(field-mode): carry elev from home observer to fix geometric horizon filter

### DIFF
--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -82,6 +82,7 @@ function AppShell() {
       updateObserver({
         lat: geo.position.lat,
         lon: geo.position.lon,
+        elev: homeObserver?.elev ?? 0,
         obstructionAngle: 0,
       })
     } else if (!fieldModeEnabled && homeObserver) {


### PR DESCRIPTION
## Summary
Field mode observer was missing `elev`, causing `observer.elev * 0.3048` to produce `NaN`. The geometric horizon check `distanceGround >= NaN` always evaluated to `false`, so every plane in the ADS-B feed passed the visibility filter and was plotted on the map.

Fix: inherit `elev` from `homeObserver` when building the field mode observer (falls back to `0` if unavailable).

## Test plan
- [ ] Enable Field Mode — confirm only horizon-constrained aircraft appear, not the full ADS-B feed
- [ ] Disable Field Mode — confirm home observer and obstruction angle restored correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)