### PR TITLE
fix(orientation): auto-register compass on Android without button tap

### DIFF
--- a/www/src/lib/orientation.js
+++ b/www/src/lib/orientation.js
@@ -11,12 +11,26 @@ export function useDeviceOrientation() {
 
   const listenerRef = useRef(null) // { eventName, handler } or null
 
-  // Check if API is available on mount
+  // Check if API is available; auto-register on Android (no permission dialog needed)
   useEffect(() => {
-    if (window.DeviceOrientationEvent || window.DeviceOrientationAbsoluteEvent) {
-      setIsSupported(true)
-    }
-  }, [])
+    const hasApi = window.DeviceOrientationEvent || window.DeviceOrientationAbsoluteEvent
+    if (!hasApi) return
+    setIsSupported(true)
+
+    // iOS requires an explicit user gesture to call requestPermission — skip auto-register
+    const needsPermission = typeof DeviceOrientationEvent !== 'undefined' &&
+      typeof DeviceOrientationEvent.requestPermission === 'function'
+    if (needsPermission) return
+
+    // Android/non-iOS: register immediately without a button tap
+    if (listenerRef.current) return
+    const eventName = 'ondeviceorientationabsolute' in window
+      ? 'deviceorientationabsolute'
+      : 'deviceorientation'
+    window.addEventListener(eventName, handleOrientation, true)
+    listenerRef.current = { eventName, handler: handleOrientation }
+    setPermissionState('granted')
+  }, [handleOrientation])
 
   const handleOrientation = useCallback((event) => {
     // Use != null so heading=0 (North) is treated as valid, not falsy


### PR DESCRIPTION
## Summary
Android does not require a permission dialog for `DeviceOrientationEvent`. Previously the listener was only registered on button tap, leaving `permissionState: 'unknown'` on Android indefinitely — compass never worked.

Fix: auto-register the listener on mount for non-iOS devices. iOS still requires the explicit button tap (browser enforces the user-gesture requirement for `requestPermission`).

## Test plan
- [ ] Android Chrome: open app — compass should auto-activate, heading updates as phone rotates
- [ ] iOS Safari: compass button still required — tap it, grant permission, heading updates
- [ ] `?debug` overlay confirms `perm: granted` and heading changes on Android without any button tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)