### PR TITLE
fix(chart): smooth heading, fix 0/360 snap, keep labels upright (#71 #72 #73)

### DIFF
--- a/www/src/components/SkyChart/SkyChart.jsx
+++ b/www/src/components/SkyChart/SkyChart.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { useMonotonicRotation } from '../../lib/rotation'
 
 // Props: { aircraft: Array<{az, el, hex, callsign, distance3d}>, variant: 'classic'|'dome', loading: bool, rotation: number }
 export default function SkyChart({ aircraft = [], variant = 'classic', loading = false, rotation = 0 }) {
@@ -39,6 +40,7 @@ function ClassicChart({ aircraft, rotation = 0 }) {
     { a: 0, l: 'N' }, { a: 45, l: 'NE' }, { a: 90, l: 'E' }, { a: 135, l: 'SE' },
     { a: 180, l: 'S' }, { a: 225, l: 'SW' }, { a: 270, l: 'W' }, { a: 315, l: 'NW' },
   ]
+  const displayRot = useMonotonicRotation(rotation)
 
   return (
     <svg
@@ -48,7 +50,7 @@ function ClassicChart({ aircraft, rotation = 0 }) {
       height="100%"
       style={{ display: 'block' }}
     >
-      <g style={{ transform: `rotate(${-rotation}deg)`, transformOrigin: `${CX}px ${CY}px`, transition: 'transform 0.5s ease' }}>
+      <g style={{ transform: `rotate(${displayRot}deg)`, transformOrigin: `${CX}px ${CY}px`, transition: 'transform 0.5s ease' }}>
         <defs>
           <radialGradient id="sc-classic-bg" cx="50%" cy="50%" r="50%">
             <stop offset="0%" stopColor="var(--surface)" />
@@ -166,6 +168,7 @@ function DomeChart({ aircraft, rotation = 0 }) {
     { a: 0, l: 'N' }, { a: 45, l: 'NE' }, { a: 90, l: 'E' }, { a: 135, l: 'SE' },
     { a: 180, l: 'S' }, { a: 225, l: 'SW' }, { a: 270, l: 'W' }, { a: 315, l: 'NW' },
   ]
+  const displayRot = useMonotonicRotation(rotation)
 
   return (
     <svg
@@ -175,7 +178,7 @@ function DomeChart({ aircraft, rotation = 0 }) {
       height="100%"
       style={{ display: 'block' }}
     >
-      <g style={{ transform: `rotate(${-rotation}deg)`, transformOrigin: `${CX}px ${CY}px`, transition: 'transform 0.5s ease' }}>
+      <g style={{ transform: `rotate(${displayRot}deg)`, transformOrigin: `${CX}px ${CY}px`, transition: 'transform 0.5s ease' }}>
         <defs>
           <radialGradient id="sc-dome-bg" cx="50%" cy="50%" r="50%">
             <stop offset="0%" stopColor="var(--surface)" />
@@ -445,6 +448,7 @@ function LoadingSweep() {
 // ─── Empty state ─────────────────────────────────────────────────────────────
 function EmptyChart({ variant, rotation = 0 }) {
   const chartClass = `sky-chart sky-chart--${variant} sky-chart--empty`
+  const displayRot = useMonotonicRotation(rotation)
 
   return (
     <svg
@@ -454,7 +458,7 @@ function EmptyChart({ variant, rotation = 0 }) {
       height="100%"
       style={{ display: 'block' }}
     >
-      <g style={{ transform: `rotate(${-rotation}deg)`, transformOrigin: `${CX}px ${CY}px`, transition: 'transform 0.5s ease' }}>
+      <g style={{ transform: `rotate(${displayRot}deg)`, transformOrigin: `${CX}px ${CY}px`, transition: 'transform 0.5s ease' }}>
         <defs>
           <radialGradient id="sc-empty-bg" cx="50%" cy="50%" r="50%">
             <stop offset="0%" stopColor="var(--surface)" />

--- a/www/src/components/SkyChart/SkyChart.jsx
+++ b/www/src/components/SkyChart/SkyChart.jsx
@@ -106,12 +106,15 @@ function ClassicChart({ aircraft, rotation = 0 }) {
         {/* Elevation labels */}
         {[30, 60].map((deg) => {
           const rr = R * (1 - deg / 90)
+          const labelY = CY - rr + 2
           return (
             <g key={deg}>
-              <rect x={CX - 10} y={CY - rr - 6} width="20" height="10" fill="var(--surface)" />
+              <rect x={CX - 10} y={CY - rr - 6} width="20" height="10" fill="var(--surface)"
+                transform={`rotate(${-displayRot}, ${CX}, ${labelY})`} />
               <text
-                x={CX} y={CY - rr + 2}
+                x={CX} y={labelY}
                 textAnchor="middle"
+                transform={`rotate(${-displayRot}, ${CX}, ${labelY})`}
                 style={{ fontSize: 8, fontFamily: 'var(--mono)', fill: 'var(--mute-2)', letterSpacing: '0.05em' }}
               >{deg}°</text>
             </g>
@@ -128,6 +131,7 @@ function ClassicChart({ aircraft, rotation = 0 }) {
               x={tx} y={ty + 3}
               textAnchor="middle"
               dominantBaseline="middle"
+              transform={`rotate(${-displayRot}, ${tx}, ${ty + 3})`}
               style={{
                 fontSize: isMajor ? 11 : 9,
                 fontFamily: 'var(--mono)',
@@ -154,6 +158,7 @@ function ClassicChart({ aircraft, rotation = 0 }) {
               callsign={ac.callsign}
               az={ac.az} el={ac.el}
               isPrimary={isPrimary}
+              rotation={-displayRot}
             />
           )
         })}
@@ -228,12 +233,15 @@ function DomeChart({ aircraft, rotation = 0 }) {
         {/* Elevation labels */}
         {[30, 60].map((deg) => {
           const rr = R * (1 - deg / 90)
+          const labelY = CY - rr + 2
           return (
             <g key={deg}>
-              <rect x={CX - 10} y={CY - rr - 6} width="20" height="10" fill="var(--surface)" />
+              <rect x={CX - 10} y={CY - rr - 6} width="20" height="10" fill="var(--surface)"
+                transform={`rotate(${-displayRot}, ${CX}, ${labelY})`} />
               <text
-                x={CX} y={CY - rr + 2}
+                x={CX} y={labelY}
                 textAnchor="middle"
+                transform={`rotate(${-displayRot}, ${CX}, ${labelY})`}
                 style={{ fontSize: 8, fontFamily: 'var(--mono)', fill: 'var(--mute-2)', letterSpacing: '0.05em' }}
               >{deg}°</text>
             </g>
@@ -250,6 +258,7 @@ function DomeChart({ aircraft, rotation = 0 }) {
               x={tx} y={ty + 3}
               textAnchor="middle"
               dominantBaseline="middle"
+              transform={`rotate(${-displayRot}, ${tx}, ${ty + 3})`}
               style={{
                 fontSize: isMajor ? 11 : 9,
                 fontFamily: 'var(--mono)',
@@ -276,6 +285,7 @@ function DomeChart({ aircraft, rotation = 0 }) {
               callsign={ac.callsign}
               az={ac.az} el={ac.el}
               isPrimary={isPrimary}
+              rotation={-displayRot}
             />
           )
         })}
@@ -285,7 +295,7 @@ function DomeChart({ aircraft, rotation = 0 }) {
 }
 
 // ─── Aircraft marker sub-component ──────────────────────────────────────────
-function AircraftMarker({ px, py, callsign, az, el, isPrimary }) {
+function AircraftMarker({ px, py, callsign, az, el, isPrimary, rotation = 0 }) {
   const transition = 'cx 0.5s ease, cy 0.5s ease'
   const labelW = (callsign ? callsign.length * 7 + 10 : 50)
 
@@ -327,8 +337,7 @@ function AircraftMarker({ px, py, callsign, az, el, isPrimary }) {
       {callsign && (
         <g
           className="sky-chart__callsign"
-          transform={`translate(${px + 10}, ${py - 12})`}
-          style={{ transition: 'transform 0.5s ease' }}
+          transform={`translate(${px + 10}, ${py - 12}) rotate(${rotation}, ${labelW / 2}, 7)`}
         >
           <rect
             x="0" y="0"
@@ -355,6 +364,7 @@ function AircraftMarker({ px, py, callsign, az, el, isPrimary }) {
       {isPrimary && (
         <text
           x={px + 10} y={py + 15}
+          transform={`rotate(${rotation}, ${px + 10}, ${py + 15})`}
           style={{
             fontSize: 8,
             fontFamily: 'var(--mono)',
@@ -496,6 +506,7 @@ function EmptyChart({ variant, rotation = 0 }) {
           const [tx, ty] = azElToXY(a, 0, CX, CY, R + 16)
           return (
             <text key={l} x={tx} y={ty + 3} textAnchor="middle" dominantBaseline="middle"
+              transform={`rotate(${-displayRot}, ${tx}, ${ty + 3})`}
               style={{ fontSize: 11, fontFamily: 'var(--mono)', fill: 'var(--ink-2)', fontWeight: 700 }}
             >{l}</text>
           )
@@ -508,6 +519,7 @@ function EmptyChart({ variant, rotation = 0 }) {
         <text
           x={CX} y={CY + 20}
           textAnchor="middle"
+          transform={`rotate(${-displayRot}, ${CX}, ${CY + 20})`}
           style={{
             fontSize: 11,
             fontFamily: 'var(--mono)',

--- a/www/src/lib/orientation.js
+++ b/www/src/lib/orientation.js
@@ -10,6 +10,9 @@ export function useDeviceOrientation() {
   const [permissionState, setPermissionState] = useState('unknown') // 'unknown' | 'granted' | 'denied'
 
   const listenerRef = useRef(null) // { eventName, handler } or null
+  const smoothedHeadingRef = useRef(null)
+
+  const ALPHA = 0.15 // smoothing factor: lower = smoother, higher = more responsive
 
   // handleOrientation must be declared before any useEffect that references it
   const handleOrientation = useCallback((event) => {
@@ -18,7 +21,13 @@ export function useDeviceOrientation() {
     if (h != null) {
       // webkitCompassHeading is already CW from North; standard alpha is CCW so invert it
       const correctedHeading = event.webkitCompassHeading != null ? h : (360 - h) % 360
-      setHeading(correctedHeading)
+      if (smoothedHeadingRef.current === null) {
+        smoothedHeadingRef.current = correctedHeading
+      } else {
+        const delta = ((correctedHeading - smoothedHeadingRef.current + 540) % 360) - 180
+        smoothedHeadingRef.current = (smoothedHeadingRef.current + ALPHA * delta + 360) % 360
+      }
+      setHeading(smoothedHeadingRef.current)
     }
   }, [])
 

--- a/www/src/lib/rotation.js
+++ b/www/src/lib/rotation.js
@@ -1,0 +1,16 @@
+import { useRef, useState, useEffect } from 'react'
+
+export function useMonotonicRotation(heading) {
+  const displayRotRef = useRef(-heading)
+  const prevHeadingRef = useRef(heading)
+  const [displayRot, setDisplayRot] = useState(-heading)
+
+  useEffect(() => {
+    const delta = ((heading - prevHeadingRef.current + 540) % 360) - 180
+    displayRotRef.current -= delta
+    prevHeadingRef.current = heading
+    setDisplayRot(displayRotRef.current)
+  }, [heading])
+
+  return displayRot
+}


### PR DESCRIPTION
## Summary

- **#73** — Apply EMA smoothing (`ALPHA=0.15`) to raw compass heading in `orientation.js`, eliminating ±2–5° sensor jitter at rest without introducing 0/360 wrap artifacts
- **#72** — Introduce `useMonotonicRotation` hook in `lib/rotation.js` that accumulates heading as a monotonic value, preventing the full-revolution CSS snap when heading crosses North
- **#71** — Counter-rotate all SVG text elements (`-displayRot`) so cardinal labels, elevation ring labels, callsign tags, AZ/EL sub-label, and empty-state text remain upright at all compass headings

## Test plan

- [ ] Hold device stationary — chart should not move (EMA suppresses jitter)
- [ ] Rotate device slowly through North (0°/360°) — chart should move a short 2° arc, not spin 358°
- [ ] Rotate to any heading — N/S/E/W/NE/SE/SW/NW labels stay upright and readable
- [ ] With aircraft in view — callsign tag and AZ/EL label stay upright and legible
- [ ] Empty state ("No aircraft") — text stays horizontal at all headings
- [ ] Rotate device multiple full revolutions — no label drift or permanent tilt

## QA

Each commit reviewed by `qa-expert` agent before inclusion. Issues found (direction sign inversion on #72, wrong angle reference on #71) were caught and corrected before merge.

Closes #71
Closes #72
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sky chart labels and aircraft markers now maintain consistent orientation regardless of rotation state.
  * Device heading tracking now responds more smoothly to device orientation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->