### PR TITLE
fix(layout): center chart header title over chart on desktop (#75)

### DIFF
--- a/skywatcher.css
+++ b/skywatcher.css
@@ -248,9 +248,11 @@ body { transition: background 0.25s var(--ease), color 0.25s var(--ease); }
 }
 
 .corners-top {
-  position: relative;
-  display: flex; justify-content: space-between; align-items: flex-start;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: flex-start;
 }
+.corners-top > :last-child { justify-self: end; }
 
 .chart-wrap {
   flex: 1;


### PR DESCRIPTION
## Summary

- `.corners-top` flex `space-between` left the "Overhead now / Where to look" title off-center whenever the mode-toggle and chart-toggle had unequal widths
- Switch to `grid-template-columns: 1fr auto 1fr` so the middle title is always geometrically centered over the chart below it
- Right child gets `justify-self: end` to maintain right-alignment

## Test plan

- [ ] On desktop: "Where to look" title is centered over the sky chart at various viewport widths
- [ ] Mode toggle (left) and chart toggle (right) remain at their edges
- [ ] Mobile layout unchanged (flex column, ≤900px)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)