### PR TITLE
fix(nginx): always revalidate index.html to prevent stale deploy cache

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,20 +35,16 @@ http {
       proxy_connect_timeout 5s;
     }
 
-    # SPA fallback for client-side routing
-    location / {
-      try_files $uri $uri/ /index.html;
-      expires 1h;
-    }
-
-    # Cache busting for versioned assets
+    # Versioned assets (content-hashed by Vite) — cache aggressively
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
       expires 30d;
       add_header Cache-Control "public, immutable";
     }
 
-    # Disable caching for index.html
-    location = /index.html {
+    # SPA fallback — always revalidate so deploys are picked up immediately
+    # (versioned asset regex above takes priority for JS/CSS/images)
+    location / {
+      try_files $uri $uri/ /index.html;
       expires -1;
       add_header Cache-Control "no-cache, no-store, must-revalidate";
     }


### PR DESCRIPTION
## Problem

`location /` set `expires 1h`, so browsers cached `index.html` for up to an hour after a deploy. The `location = /index.html` `no-cache` block only fires on direct requests to `/index.html` — it is **not** reached when nginx serves `index.html` via the `try_files` SPA fallback (which runs inside the `location /` context). Result: new JS bundle filenames in a fresh `index.html` aren't seen by the browser until the hour-long cache expires.

## Fix

- Move the versioned-asset regex block (`~* \.(js|css|...)$`) **above** `location /` so it takes priority for assets
- Set `no-cache, no-store, must-revalidate` on `location /` directly
- Remove the now-redundant `location = /index.html` block

Vite content-hashes all JS/CSS filenames on every build, so those files are safe to cache indefinitely. Only `index.html` (and unknown routes served by the SPA fallback) needs to be revalidated — and now it always will be.

## Test plan

- [ ] After a deploy, hard-reload clears stale state (expected); a normal reload also picks up new JS immediately
- [ ] Browser DevTools → Network → `index.html` shows `Cache-Control: no-cache, no-store, must-revalidate`
- [ ] JS/CSS assets still show `Cache-Control: public, immutable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)