### PR TITLE
feat(context): default to field mode on Tesla browser (#85)

### DIFF
--- a/www/src/contexts/SettingsContext.jsx
+++ b/www/src/contexts/SettingsContext.jsx
@@ -13,7 +13,16 @@ const defaults = {
 function loadSettings() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    return raw ? { ...defaults, ...JSON.parse(raw) } : defaults
+    const stored = raw ? JSON.parse(raw) : null
+    const settings = { ...defaults, ...(stored ?? {}) }
+
+    // No stored mode preference + Tesla browser → default to field mode
+    const noStoredMode = !stored || stored.fieldModeEnabled === undefined
+    if (noStoredMode && navigator.userAgent.toLowerCase().includes('tesla')) {
+      settings.fieldModeEnabled = true
+    }
+
+    return settings
   } catch {
     return defaults
   }


### PR DESCRIPTION
## Summary

When SkyWatcher loads on a Tesla vehicle browser with no stored mode preference, `loadSettings()` now initialises `fieldModeEnabled: true` so the user lands directly in live GPS mode.

**Detection:** `navigator.userAgent.toLowerCase().includes('tesla')` — case-insensitive, matches any Tesla UA variant.

**Fires only when no preference is stored:** if `fieldModeEnabled` exists in localStorage (set by a previous manual switch, GPS-loss revert, or existing session), the stored value is used and Tesla detection is skipped entirely. No infinite Field→Home→Field cycle.

## Changes
- `www/src/contexts/SettingsContext.jsx` — `loadSettings()` only. One file, no backend, no new env vars, no UI changes.

## Test plan
- [ ] Clear localStorage, open on a UA containing "tesla" → app starts in Field mode
- [ ] Clear localStorage, open on a normal UA → app starts in Home mode (no regression)
- [ ] Set `fieldModeEnabled: false` in localStorage, open on Tesla UA → stored value respected, stays Home
- [ ] Let GPS fail (2 consecutive failures) → auto-reverts to Home, writes to localStorage → reload → Tesla detection bypassed, stays Home

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Field mode is now automatically enabled for users accessing the app from Tesla browsers when no stored preference exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->