### PR TITLE
Fix: inherit obstructionAngle in field mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 # IDE
 .vscode/
 .idea/
+.worktrees/

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -83,7 +83,7 @@ function AppShell() {
         lat: geo.position.lat,
         lon: geo.position.lon,
         elev: homeObserver?.elev ?? 0,
-        obstructionAngle: 0,
+        obstructionAngle: homeObserver?.obstructionAngle ?? 14.2,
       })
     } else if (!fieldModeEnabled && homeObserver) {
       // homeObserver guard is intentional — null means first-run setup hasn't


### PR DESCRIPTION
Resolves #87. Inherits the obstruction angle from the home observer in field mode instead of hardcoding 0, preventing the UI from being flooded with planes that should be hidden by local obstructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPS field mode to properly preserve obstruction angle settings during observer updates instead of resetting to default values.

* **Chores**
  * Updated version control configuration to exclude development worktrees directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->