### PR TITLE
fix(mobile): fix landscape layout overflow and sky chart sizing

### DIFF
--- a/skywatcher.css
+++ b/skywatcher.css
@@ -278,7 +278,7 @@ body { transition: background 0.25s var(--ease), color 0.25s var(--ease); }
   .main { display: grid; grid-template-columns: 1.15fr 1fr; overflow: hidden; flex: 1; height: auto; }
   .left-pane { min-height: 0; overflow: hidden; border-right: 1px solid var(--line); border-bottom: none; }
   .chart-wrap { flex: 1; aspect-ratio: unset; max-width: unset; min-height: 0; width: auto; margin: 0; }
-  .right-pane { overflow-y: auto; height: auto; }
+  .right-pane { overflow-y: auto; height: auto; min-height: 0; }
 }
 
 .bearing-strip {

--- a/skywatcher.css
+++ b/skywatcher.css
@@ -277,7 +277,7 @@ body { transition: background 0.25s var(--ease), color 0.25s var(--ease); }
   .app { height: 100dvh; overflow: hidden; }
   .main { display: grid; grid-template-columns: 1.15fr 1fr; overflow: hidden; flex: 1; height: auto; }
   .left-pane { min-height: 0; overflow: hidden; border-right: 1px solid var(--line); border-bottom: none; }
-  .chart-wrap { flex: 1; aspect-ratio: unset; max-width: unset; min-height: 0; width: auto; margin: 0; }
+  .chart-wrap { flex: 1; aspect-ratio: 1 / 1; max-width: unset; min-height: 0; width: auto; margin: 0; align-self: center; }
   .right-pane { overflow-y: auto; height: auto; min-height: 0; }
 }
 


### PR DESCRIPTION
## Summary
- Fix mobile landscape layout scrolling instead of fitting viewport (min-height: 0 on right-pane)
- Restore sky chart square aspect-ratio in landscape so the chart fills available height

## Changes
- `skywatcher.css`: added `min-height: 0` to `.right-pane` in landscape media query
- `skywatcher.css`: restored `aspect-ratio: 1 / 1` and added `align-self: center` to `.chart-wrap` in landscape media query

Closes #64
Closes #58

## Test plan
- [ ] Open at 844×390 viewport (DevTools landscape mobile)
- [ ] Page fits in view without scrolling
- [ ] Sky chart is a proper square filling available height

🤖 Generated with [Claude Code](https://claude.com/claude-code)