### PR TITLE
feat(ux): tooltips, quota badge redesign, and history card interaction

### DIFF
--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -166,7 +166,7 @@ function AppShell() {
 
             <div className="bearing-strip">
               <div className="stat lg">
-                <div className="stat-k">Azimuth</div>
+                <div className="stat-k" title="Azimuth: compass direction to the aircraft (0°=North, 90°=East, 180°=South)">Azimuth</div>
                 <div className="stat-v accent mono">
                   {currentAircraft ? `${Math.round(currentAircraft.az)}°` : '—'}
                 </div>

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -143,12 +143,14 @@ function AppShell() {
                 <button
                   className={variant === 'classic' ? 'active' : ''}
                   onClick={() => updateSettings({ chartVariant: 'classic' })}
+                  title="Classic: top-down polar compass view showing azimuth and elevation rings"
                 >
                   Classic
                 </button>
                 <button
                   className={variant === 'dome' ? 'active' : ''}
                   onClick={() => updateSettings({ chartVariant: 'dome' })}
+                  title="Dome: perspective projection showing the sky as a curved bowl"
                 >
                   Dome
                 </button>

--- a/www/src/components/HistoryPanel/HistoryPanel.jsx
+++ b/www/src/components/HistoryPanel/HistoryPanel.jsx
@@ -6,7 +6,7 @@ import { AircraftContext } from '../../contexts/AircraftContext'
  * Data is sourced from AircraftContext.history (managed by useHistory hook).
  */
 export default function HistoryPanel() {
-  const { history, currentAircraft } = useContext(AircraftContext)
+  const { history, currentAircraft, setCurrentAircraft } = useContext(AircraftContext)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
@@ -28,6 +28,7 @@ export default function HistoryPanel() {
             <div
               key={entry.hex}
               className={`hist-card${isActive ? ' active' : ''}`}
+              onClick={() => setCurrentAircraft(entry)}
               style={{
                 flex: '0 0 auto',
                 minWidth: 118,

--- a/www/src/components/HistoryPanel/HistoryPanel.jsx
+++ b/www/src/components/HistoryPanel/HistoryPanel.jsx
@@ -6,7 +6,7 @@ import { AircraftContext } from '../../contexts/AircraftContext'
  * Data is sourced from AircraftContext.history (managed by useHistory hook).
  */
 export default function HistoryPanel() {
-  const { history, currentAircraft, setCurrentAircraft } = useContext(AircraftContext)
+  const { history, currentAircraft, setCurrentAircraft, visibleAircraft } = useContext(AircraftContext)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
@@ -24,11 +24,26 @@ export default function HistoryPanel() {
         )}
         {history.map((entry) => {
           const isActive = currentAircraft?.hex === entry.hex
+          const liveAircraft = visibleAircraft.find(a => a.hex === entry.hex)
+          const isLive = Boolean(liveAircraft)
+
+          const handleSelect = () => {
+            if (liveAircraft) setCurrentAircraft(liveAircraft)
+          }
+
           return (
             <div
               key={entry.hex}
+              role="button"
+              tabIndex={isLive ? 0 : -1}
               className={`hist-card${isActive ? ' active' : ''}`}
-              onClick={() => setCurrentAircraft(entry)}
+              onClick={handleSelect}
+              onKeyDown={(e) => {
+                if (isLive && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault()
+                  handleSelect()
+                }
+              }}
               style={{
                 flex: '0 0 auto',
                 minWidth: 118,
@@ -39,6 +54,8 @@ export default function HistoryPanel() {
                 display: 'flex',
                 flexDirection: 'column',
                 gap: 2,
+                opacity: isLive ? 1 : 0.5,
+                cursor: isLive ? 'pointer' : 'default',
               }}
             >
               <div

--- a/www/src/components/StatusBar/StatusBar.jsx
+++ b/www/src/components/StatusBar/StatusBar.jsx
@@ -119,7 +119,7 @@ export default function StatusBar({ orientation }) {
           const pct = limit > 0 ? quota.used / limit : 0
           if (pct >= 1) {
             return (
-              <span className="quota-badge" style={{ color: 'var(--warn)', borderColor: 'var(--warn)' }}
+              <span className="quota-badge" style={{ color: 'var(--warn)' }}
                 title={`FlightAware quota full (${quota.used}/${limit} calls used today)`}>
                 FA quota full
               </span>
@@ -127,7 +127,7 @@ export default function StatusBar({ orientation }) {
           }
           if (pct >= 0.8) {
             return (
-              <span className="quota-badge" style={{ color: 'var(--warn)', borderColor: 'var(--warn)' }}
+              <span className="quota-badge" style={{ color: 'var(--warn)' }}
                 title={`FlightAware quota low (${quota.used}/${limit} calls used today)`}>
                 FA quota low
               </span>

--- a/www/src/components/StatusBar/StatusBar.jsx
+++ b/www/src/components/StatusBar/StatusBar.jsx
@@ -114,11 +114,32 @@ export default function StatusBar({ orientation }) {
         {pollingStatus === 'error' && (
           <span className="poll-ring" style={{ color: 'var(--warn)' }}>RECEIVER ERROR</span>
         )}
-        {quota && (
-          <span className="quota-badge">
-            FA {quota.used}/{quota.softLimit ?? quota.limit}
-          </span>
-        )}
+        {quota && (() => {
+          const limit = quota.softLimit ?? quota.limit
+          const pct = limit > 0 ? quota.used / limit : 0
+          if (pct >= 1) {
+            return (
+              <span className="quota-badge" style={{ color: 'var(--warn)', borderColor: 'var(--warn)' }}
+                title={`FlightAware quota full (${quota.used}/${limit} calls used today)`}>
+                FA quota full
+              </span>
+            )
+          }
+          if (pct >= 0.8) {
+            return (
+              <span className="quota-badge" style={{ color: 'var(--warn)', borderColor: 'var(--warn)' }}
+                title={`FlightAware quota low (${quota.used}/${limit} calls used today)`}>
+                FA quota low
+              </span>
+            )
+          }
+          return (
+            <span className="quota-badge"
+              title={`FlightAware enrichment active (${quota.used}/${limit} calls used today)`}>
+              FA
+            </span>
+          )
+        })()}
       </div>
 
       <div className="statusbar-right">

--- a/www/src/components/TransponderPanel/TransponderPanel.jsx
+++ b/www/src/components/TransponderPanel/TransponderPanel.jsx
@@ -1,10 +1,10 @@
 import { useContext } from 'react'
 import { AircraftContext } from '../../contexts/AircraftContext'
 
-function Row({ label, value, unit, accent }) {
+function Row({ label, value, unit, accent, title }) {
   return (
     <div className="row">
-      <span className="row-k">{label}</span>
+      <span className="row-k" title={title}>{label}</span>
       <span className={`row-v${accent ? ' accent' : ''}`}>
         {value}
         {unit && <span className="u">{unit}</span>}
@@ -72,15 +72,15 @@ export default function TransponderPanel() {
         <Row label="Altitude" value={formatAlt(alt_baro)} unit="ft" accent />
         <Row label="Ground speed" value={gs != null ? Math.round(gs) : '—'} unit="kts" />
         <Row label="Heading" value={track != null ? `${Math.round(track)}°` : '—'} />
-        <Row label="Vertical rate" value={formatVRate(baro_rate)} unit="fpm" />
-        <Row label="Squawk" value={squawk || '—'} />
-        <Row label="ICAO" value={hex?.toUpperCase() || '—'} />
+        <Row label="Vertical rate" value={formatVRate(baro_rate)} unit="fpm" title="Vertical rate: rate of climb or descent in feet per minute" />
+        <Row label="Squawk" value={squawk || '—'} title="Squawk code: 4-digit octal code assigned by ATC to identify this aircraft on radar" />
+        <Row label="ICAO" value={hex?.toUpperCase() || '—'} title="ICAO 24-bit hex address: unique identifier assigned to this aircraft" />
         <Row
           label="Distance"
           value={dist === '—' ? '—' : dist.value}
           unit={dist === '—' ? undefined : dist.unit}
         />
-        <Row label="Azimuth" value={az != null ? `${Math.round(az)}°` : '—'} />
+        <Row label="Azimuth" value={az != null ? `${Math.round(az)}°` : '—'} title="Azimuth: compass direction to the aircraft (0°=North, 90°=East, 180°=South)" />
         <Row label="Elevation" value={el != null ? `${Math.round(el)}°` : '—'} />
         {dir && <Row label="Direction" value={dir} />}
       </div>


### PR DESCRIPTION
## Summary
- Add plain-English `title` tooltips to aviation jargon terms (Squawk, ICAO, Azimuth, Vertical Rate)
- Add `title` explanations to Classic/Dome chart toggle buttons
- Simplify FA quota badge — hide numeric count, show colored warnings at ≥80% and ≥100% usage
- Fix history card false affordance — clicking now selects the live aircraft, with a11y support

## Changes
- `TransponderPanel.jsx`: title attributes on Squawk, ICAO, Vertical Rate rows
- `App.jsx`: title on Azimuth stat and Classic/Dome buttons
- `StatusBar.jsx`: quota badge replaced with threshold-based warnings using var(--warn)
- `HistoryPanel.jsx`: onClick looks up live aircraft by hex, role=button, tabIndex, onKeyDown

Closes #70
Closes #69
Closes #67
Closes #68

## Test plan
- [ ] Hover over Squawk/ICAO/Azimuth/Vertical Rate — tooltips appear
- [ ] Hover Classic/Dome buttons — tooltips appear
- [ ] At >80% FA quota: badge shows "FA quota low" in gold
- [ ] At 100% FA quota: badge shows "FA quota full" in gold
- [ ] Click a currently-visible history card — aircraft is selected and panels update
- [ ] Click a no-longer-visible history card — no action, card is dimmed
- [ ] Tab to a history card and press Enter — same selection behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live aircraft selection now available from history panel with keyboard support (Enter/Space keys).
  * Dynamic quota status indicators replace static badge text with warning states.

* **Improvements**
  * Added contextual tooltips throughout the interface for chart variants, bearing directions, and transponder fields to enhance usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->