### PR TITLE
feat(bearing-strip): replace numeric labels with descriptive text

### DIFF
--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -83,7 +83,7 @@ function formatDistanceKm(m) {
 function AppShell() {
   useAdsbPoller()
   const orientation = useDeviceOrientation()
-  const { heading } = orientation
+  const { heading, permissionState } = orientation
   // heading drives compass rotation in both Home and Field Mode — no change
   // needed here; Field Mode GPS position is handled via observer in context
 
@@ -180,12 +180,16 @@ function AppShell() {
 
             <div className="bearing-strip">
               <div className="stat lg">
-                <div className="stat-k" title="Azimuth: compass direction to the aircraft (0°=North, 90°=East, 180°=South)">Azimuth</div>
+                <div className="stat-k">Azimuth</div>
                 <div className="stat-v accent mono">
                   {currentAircraft ? `${Math.round(currentAircraft.az)}°` : '—'}
                 </div>
                 <div className="stat-sub">
-                  {currentAircraft ? azToCardinal(currentAircraft.az) : ''}
+                  {currentAircraft
+                    ? permissionState === 'granted'
+                      ? azToRelative(currentAircraft.az, heading)
+                      : azToCardinal(currentAircraft.az)
+                    : ''}
                 </div>
               </div>
               <div className="stat lg">

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -56,6 +56,20 @@ function azToCardinal(deg) {
   return dirs[Math.round(((deg % 360) + 360) % 360 / 45) % 8]
 }
 
+function azToRelative(aircraftAz, userHeading) {
+  const rel = (((aircraftAz - userHeading) % 360) + 360) % 360
+  const dirs = ['Ahead', 'Ahead-Right', 'Right', 'Behind-Right', 'Behind', 'Behind-Left', 'Left', 'Ahead-Left']
+  return dirs[Math.round(rel / 45) % 8]
+}
+
+function elToBand(el) {
+  if (el >= 75) return 'Overhead'
+  if (el >= 45) return 'High'
+  if (el >= 20) return 'Mid'
+  if (el >= 5) return 'Low'
+  return 'Horizon'
+}
+
 function formatDistanceNm(m) {
   if (m == null) return '—'
   return `${(m / 1852).toFixed(1)} nm`
@@ -166,7 +180,7 @@ function AppShell() {
 
             <div className="bearing-strip">
               <div className="stat lg">
-                <div className="stat-k">Azimuth</div>
+                <div className="stat-k" title="Azimuth: compass direction to the aircraft (0°=North, 90°=East, 180°=South)">Azimuth</div>
                 <div className="stat-v accent mono">
                   {currentAircraft ? `${Math.round(currentAircraft.az)}°` : '—'}
                 </div>
@@ -179,7 +193,9 @@ function AppShell() {
                 <div className="stat-v accent mono">
                   {currentAircraft ? `${Math.round(currentAircraft.el)}°` : '—'}
                 </div>
-                <div className="stat-sub">up from horizon</div>
+                <div className="stat-sub">
+                  {currentAircraft ? elToBand(currentAircraft.el) : ''}
+                </div>
               </div>
               <div className="stat lg">
                 <div className="stat-k">Distance</div>


### PR DESCRIPTION
## Summary
- Elevation sub-label replaced with natural-language band: Overhead / High / Mid / Low / Horizon
- Azimuth sub-label replaced with 8-point cardinal directions, or relative directions (Ahead, Right, etc.) when compass is active

## Changes
- `App.jsx`: added `elToBand(el)` and `azToRelative(aircraftAz, userHeading)` helpers
- `App.jsx`: bearing strip now uses band text for elevation and directional text for azimuth
- Relative directions activate when `permissionState === 'granted'` (compass active)

Closes #82
Closes #81

## Test plan
- [ ] Elevation label shows "High", "Mid", "Low", etc. for aircraft at different elevations
- [ ] Without compass: azimuth shows "NE", "SW", etc.
- [ ] With compass enabled: azimuth shows "Ahead", "Right", "Behind-Left", etc. relative to heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)