### PR TITLE
feat(data): skip AeroAPI when tab hidden; US Imperial units

### DIFF
--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -12,6 +12,7 @@ import TransponderPanel from './components/TransponderPanel'
 import HistoryPanel from './components/HistoryPanel/HistoryPanel'
 import StatusBar from './components/StatusBar/StatusBar'
 import { useGeolocation, GEOLOCATION_FAILURE_THRESHOLD } from './lib/geolocation'
+import { fmtDist } from './lib/units'
 
 export default function App() {
   const { observer, updateObserver, captureHomeObserver, updateWorkObserver, locationMode, updateSettings } = useContext(SettingsContext)
@@ -85,16 +86,6 @@ function elToBand(el) {
   if (el >= 20) return 'Mid'
   if (el >= 5) return 'Low'
   return 'Horizon'
-}
-
-function formatDistanceNm(m) {
-  if (m == null) return '—'
-  return `${(m / 1852).toFixed(1)} nm`
-}
-
-function formatDistanceKm(m) {
-  if (m == null) return null
-  return m >= 1000 ? `${(m / 1000).toFixed(1)} km` : `${Math.round(m)} m`
 }
 
 function AppShell() {
@@ -243,10 +234,7 @@ function AppShell() {
               <div className="stat lg">
                 <div className="stat-k">Distance</div>
                 <div className="stat-v mono">
-                  {currentAircraft ? formatDistanceNm(currentAircraft.distance3d) : '—'}
-                </div>
-                <div className="stat-sub">
-                  {currentAircraft ? formatDistanceKm(currentAircraft.distance3d) : ''}
+                  {currentAircraft ? fmtDist(currentAircraft.distance3d) : '—'}
                 </div>
               </div>
             </div>

--- a/www/src/components/TransponderPanel/TransponderPanel.jsx
+++ b/www/src/components/TransponderPanel/TransponderPanel.jsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react'
 import { AircraftContext } from '../../contexts/AircraftContext'
+import { fmtDist, fmtSpeed, fmtAlt } from '../../lib/units'
 
 function Row({ label, value, unit, accent, title }) {
   return (
@@ -13,27 +14,11 @@ function Row({ label, value, unit, accent, title }) {
   )
 }
 
-function formatAlt(alt) {
-  if (alt == null || alt === 'ground') return 'GND'
-  const n = typeof alt === 'string' ? parseInt(alt, 10) : alt
-  if (isNaN(n)) return '—'
-  return n.toLocaleString()
-}
-
 function formatVRate(baro_rate) {
   if (baro_rate == null) return '—'
   const n = Math.round(baro_rate)
   if (n > 0) return `+${n}`
   return String(n)
-}
-
-function formatDistance(distance3d) {
-  if (distance3d == null) return '—'
-  // distance3d is in metres
-  if (distance3d >= 10000) {
-    return { value: (distance3d / 1000).toFixed(1), unit: 'km' }
-  }
-  return { value: Math.round(distance3d).toLocaleString(), unit: 'm' }
 }
 
 const COMPASS = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW']
@@ -59,27 +44,22 @@ export default function TransponderPanel() {
 
   const {
     alt_baro, gs, track, baro_rate, squawk, hex,
-    az, el, distance3d, distanceGround,
+    az, el, distance3d,
   } = currentAircraft
 
-  const dist = formatDistance(distance3d)
   const dir = compassDir(az)
 
   return (
     <div>
       <div className="label" style={{ marginBottom: 6 }}>Transponder · live ADS-B</div>
       <div className="grid-rows">
-        <Row label="Altitude" value={formatAlt(alt_baro)} unit="ft" accent />
-        <Row label="Ground speed" value={gs != null ? Math.round(gs) : '—'} unit="kts" />
+        <Row label="Altitude" value={fmtAlt(alt_baro)} accent />
+        <Row label="Ground speed" value={fmtSpeed(gs)} />
         <Row label="Heading" value={track != null ? `${Math.round(track)}°` : '—'} />
         <Row label="Vertical rate" value={formatVRate(baro_rate)} unit="fpm" title="Vertical rate: rate of climb or descent in feet per minute" />
         <Row label="Squawk" value={squawk || '—'} title="Squawk code: 4-digit octal code assigned by ATC to identify this aircraft on radar" />
         <Row label="ICAO" value={hex?.toUpperCase() || '—'} title="ICAO 24-bit hex address: unique identifier assigned to this aircraft" />
-        <Row
-          label="Distance"
-          value={dist === '—' ? '—' : dist.value}
-          unit={dist === '—' ? undefined : dist.unit}
-        />
+        <Row label="Distance" value={fmtDist(distance3d)} />
         <Row label="Azimuth" value={az != null ? `${Math.round(az)}°` : '—'} title="Azimuth: compass direction to the aircraft (0°=North, 90°=East, 180°=South)" />
         <Row label="Elevation" value={el != null ? `${Math.round(el)}°` : '—'} />
         {dir && <Row label="Direction" value={dir} />}

--- a/www/src/contexts/AircraftContext.jsx
+++ b/www/src/contexts/AircraftContext.jsx
@@ -35,10 +35,28 @@ export function AircraftProvider({ children }) {
     setEnrichment(null)
     enrichAircraft(callsign).then((result) => {
       if (cancelled) return
+      // Discard the sentinel so a skipped fetch doesn't clobber prior enrichment.
+      if (result?.skipped) return
       setEnrichment(result)
       if (result && !result.error) getQuota().then(setQuota)
     })
     return () => { cancelled = true }
+  }, [callsign])
+
+  // Re-trigger enrichment when the tab becomes visible again so we catch up
+  // on any callsign that was skipped while the tab was hidden.
+  useEffect(() => {
+    function handleVisibilityChange() {
+      if (document.visibilityState !== 'visible') return
+      if (!callsign) return
+      enrichAircraft(callsign).then((result) => {
+        if (result?.skipped || result?.error) return
+        setEnrichment(result)
+        getQuota().then(setQuota)
+      })
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
   }, [callsign])
 
   return (

--- a/www/src/lib/enrichment.js
+++ b/www/src/lib/enrichment.js
@@ -71,6 +71,11 @@ function writeCache(callsign, data) {
  * @returns {Promise<object>} Enrichment data or an error descriptor object.
  */
 export async function enrichAircraft(callsign) {
+  // Skip API calls when the browser tab is not visible to preserve daily quota.
+  if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+    return { skipped: true }
+  }
+
   const normalised = callsign.trim().toUpperCase()
 
   const cached = readCache(normalised)

--- a/www/src/lib/units.js
+++ b/www/src/lib/units.js
@@ -1,0 +1,54 @@
+/**
+ * Unit conversion and formatting utilities for US Imperial display.
+ *
+ * @module units
+ */
+
+const METERS_PER_MILE = 1609.344
+const FEET_PER_METER = 3.28084
+const MPH_PER_KNOT = 1.15078
+
+/**
+ * Format a distance in meters as miles or feet.
+ *
+ * Displays miles when the distance is >= 0.1 mi (160.9344 m),
+ * otherwise displays feet.
+ *
+ * @param {number | null | undefined} meters - Distance in metres.
+ * @returns {string} Formatted string, e.g. "12.3 mi" or "425 ft". Returns "—" for null/undefined.
+ */
+export function fmtDist(meters) {
+  if (meters == null) return '—'
+  const miles = meters / METERS_PER_MILE
+  if (miles >= 0.1) {
+    return `${miles.toFixed(1)} mi`
+  }
+  const feet = Math.round(meters * FEET_PER_METER)
+  return `${feet.toLocaleString()} ft`
+}
+
+/**
+ * Format a speed in knots as mph.
+ *
+ * @param {number | null | undefined} knots - Speed in knots.
+ * @returns {string} Formatted string, e.g. "456 mph". Returns "—" for null/undefined.
+ */
+export function fmtSpeed(knots) {
+  if (knots == null) return '—'
+  return `${Math.round(knots * MPH_PER_KNOT)} mph`
+}
+
+/**
+ * Format an altitude in feet with thousands separator.
+ *
+ * @param {number | string | null | undefined} feet - Altitude in feet, or the
+ *   string "ground".
+ * @returns {string} Formatted string, e.g. "35,000 ft". Returns "GND" for
+ *   ground/null/invalid.
+ */
+export function fmtAlt(feet) {
+  if (feet == null || feet === 'ground') return 'GND'
+  const n = typeof feet === 'string' ? parseInt(feet, 10) : feet
+  if (isNaN(n)) return '—'
+  return `${n.toLocaleString()} ft`
+}


### PR DESCRIPTION
## Summary
- Skip FlightAware AeroAPI calls when the browser tab is not visible, preserving the daily quota
- Standardise all displayed units to US Imperial: miles/feet for distance, mph for speed, feet for altitude

## Changes
- `lib/enrichment.js`: guard on `document.visibilityState` at start of `enrichAircraft()`
- `contexts/AircraftContext.jsx`: visibilitychange listener re-triggers enrichment on tab focus
- `lib/units.js` (new): `fmtDist(meters)`, `fmtSpeed(knots)`, `fmtAlt(feet)` utility functions
- `App.jsx`: removed `formatDistanceNm`/`formatDistanceKm`, bearing strip uses `fmtDist`
- `TransponderPanel.jsx`: uses `fmtAlt`, `fmtSpeed`, `fmtDist` instead of local helpers

Closes #78
Closes #83

## Test plan
- [ ] Switch to another tab — no AeroAPI calls in Network tab
- [ ] Switch back — enrichment fires for current aircraft
- [ ] Distance shows "12.3 mi" or "425 ft" depending on range
- [ ] Speed shows "456 mph" (not knots)
- [ ] Altitude shows "35,000 ft"

🤖 Generated with [Claude Code](https://claude.com/claude-code)