### PR TITLE
feat(location): Work observer and 3-state Home/Work/Field mode selector

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -28,6 +28,13 @@ const runtimeConfig = {
   obstructionAngle: process.env.OBSTRUCTION_ANGLE ?? '14.2',
 };
 
+// Work location — read-only from env, never persisted or overwritten by setup flow
+const workConfig = {
+  lat: process.env.WORK_LAT || null,
+  lon: process.env.WORK_LON || null,
+  elev: process.env.WORK_ELEV || null,
+};
+
 // ─── Setup auth state ────────────────────────────────────────────────────────
 
 // One-time setup token generated at startup and logged to stdout.
@@ -382,14 +389,24 @@ app.get('/api/fa-usage', (_req, res) => {
 // ─── GET /api/config ──────────────────────────────────────────────────────────
 
 app.get('/api/config', (_req, res) => {
-  return res.json({
+  const payload = {
     adsbUrl: runtimeConfig.adsbUrl,
     lat: runtimeConfig.lat,
     lon: runtimeConfig.lon,
     elev: runtimeConfig.elev,
     obstructionAngle: runtimeConfig.obstructionAngle,
     faKeyConfigured: Boolean(process.env.FLIGHTAWARE_API_KEY),
-  });
+  };
+
+  // Only include work fields when all three env vars are configured
+  const workConfigured = Boolean(workConfig.lat && workConfig.lon && workConfig.elev);
+  if (workConfigured) {
+    payload.workLat = workConfig.lat;
+    payload.workLon = workConfig.lon;
+    payload.workElev = workConfig.elev;
+  }
+
+  return res.json(payload);
 });
 
 // ─── POST /api/setup ──────────────────────────────────────────────────────────

--- a/skywatcher.css
+++ b/skywatcher.css
@@ -334,6 +334,25 @@ body { transition: background 0.25s var(--ease), color 0.25s var(--ease); }
 }
 .mode-toggle.active { background: var(--acc); color: var(--surface); }
 
+/* 3-state location mode selector: Home | Work | Field */
+.mode-selector {
+  display: inline-flex;
+  gap: 0;
+  border: 1px solid var(--line);
+  padding: 2px;
+  background: var(--surface-2);
+  border-radius: 3px;
+}
+.mode-selector button {
+  padding: 5px 12px; font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.1em; text-transform: uppercase; font-weight: 600;
+  border: none; cursor: pointer; background: transparent;
+  color: var(--mute); border-radius: 2px;
+  transition: all 0.18s var(--ease);
+}
+.mode-selector button.active { background: var(--ink); color: var(--surface); }
+.mode-selector button:disabled { opacity: 0.35; cursor: default; }
+
 /* Aircraft identity block */
 .identity-head {
   display: flex; justify-content: space-between; align-items: flex-start; gap: 16px;

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -14,7 +14,7 @@ import StatusBar from './components/StatusBar/StatusBar'
 import { useGeolocation, GEOLOCATION_FAILURE_THRESHOLD } from './lib/geolocation'
 
 export default function App() {
-  const { observer, updateObserver, captureHomeObserver } = useContext(SettingsContext)
+  const { observer, updateObserver, captureHomeObserver, updateWorkObserver, locationMode, updateSettings } = useContext(SettingsContext)
   // null = checking, true = configured, false = needs first-run
   const [configured, setConfigured] = useState(null)
 
@@ -36,6 +36,23 @@ export default function App() {
             obstructionAngle: parseFloat(cfg.obstructionAngle ?? 14.2),
           })
           captureHomeObserver()
+        }
+
+        // Hydrate work observer if the server has it configured
+        if (cfg.workLat && cfg.workLon && cfg.workElev) {
+          updateWorkObserver({
+            lat: parseFloat(cfg.workLat),
+            lon: parseFloat(cfg.workLon),
+            elev: parseFloat(cfg.workElev),
+            obstructionAngle: parseFloat(cfg.obstructionAngle ?? 14.2),
+          })
+        } else {
+          // Work env vars removed — if stored mode was 'work', revert to home
+          // so the user isn't left with an invisible active selection.
+          updateWorkObserver(null)
+          if (locationMode === 'work') {
+            updateSettings({ locationMode: 'home' })
+          }
         }
       })
       .catch(() => setConfigured(false))
@@ -74,35 +91,39 @@ function AppShell() {
   // needed here; Field Mode GPS position is handled via observer in context
 
   const { visibleAircraft, currentAircraft, pollingStatus } = useContext(AircraftContext)
-  const { chartVariant, updateSettings, updateObserver, fieldModeEnabled, homeObserver } = useContext(SettingsContext)
+  const { chartVariant, updateSettings, updateObserver, locationMode, homeObserver, workObserver } = useContext(SettingsContext)
+  const fieldModeEnabled = locationMode === 'field'
   const geo = useGeolocation(fieldModeEnabled)
 
   useEffect(() => {
-    if (fieldModeEnabled && geo.position) {
+    // Guard: wait until home observer is populated from server config
+    if (!homeObserver) return
+
+    if (locationMode === 'field' && geo.position) {
       updateObserver({
         lat: geo.position.lat,
         lon: geo.position.lon,
-        elev: homeObserver?.elev ?? 0,
-        obstructionAngle: homeObserver?.obstructionAngle ?? 14.2,
+        elev: homeObserver.elev ?? 0,
+        obstructionAngle: homeObserver.obstructionAngle ?? 14.2,
       })
-    } else if (!fieldModeEnabled && homeObserver) {
-      // homeObserver guard is intentional — null means first-run setup hasn't
-      // completed yet, so there's nothing to restore
+    } else if (locationMode === 'work' && workObserver) {
+      updateObserver(workObserver)
+    } else if (locationMode === 'home') {
       updateObserver(homeObserver)
     }
-  }, [fieldModeEnabled, geo.position, homeObserver, updateObserver])
+  }, [locationMode, geo.position, homeObserver, workObserver, updateObserver])
 
   const hasWarnedRef = useRef(false)
 
   useEffect(() => {
-    if (fieldModeEnabled && geo.consecutiveFailures >= GEOLOCATION_FAILURE_THRESHOLD) {
+    if (locationMode === 'field' && geo.consecutiveFailures >= GEOLOCATION_FAILURE_THRESHOLD) {
       if (!hasWarnedRef.current) {
         console.warn('[field-mode] GPS signal lost; reverting to Home Mode')
         hasWarnedRef.current = true
       }
-      updateSettings({ fieldModeEnabled: false })
+      updateSettings({ locationMode: 'home' })
     }
-  }, [fieldModeEnabled, geo.consecutiveFailures, updateSettings])
+  }, [locationMode, geo.consecutiveFailures, updateSettings])
 
   const showWeather = visibleAircraft.length === 0 && pollingStatus === 'active'
   const variant = chartVariant || 'classic'
@@ -127,14 +148,29 @@ function AppShell() {
         <div className="main">
           <div className="left-pane">
             <div className="corners-top">
-              {geo.isSupported && !geo.isDenied && (
+              <div className="mode-selector">
                 <button
-                  className={`mode-toggle${fieldModeEnabled ? ' active' : ''}`}
-                  onClick={() => updateSettings({ fieldModeEnabled: !fieldModeEnabled })}
+                  className={locationMode === 'home' ? 'active' : ''}
+                  onClick={() => updateSettings({ locationMode: 'home' })}
                 >
-                  {fieldModeEnabled ? 'Field' : 'Home'}
+                  Home
                 </button>
-              )}
+                <button
+                  className={locationMode === 'work' ? 'active' : ''}
+                  disabled={!workObserver}
+                  onClick={() => updateSettings({ locationMode: 'work' })}
+                >
+                  Work
+                </button>
+                {geo.isSupported && !geo.isDenied && (
+                  <button
+                    className={locationMode === 'field' ? 'active' : ''}
+                    onClick={() => updateSettings({ locationMode: 'field' })}
+                  >
+                    Field
+                  </button>
+                )}
+              </div>
               <div>
                 <h2 className="section-title">Overhead now</h2>
                 <div className="label">Where to look</div>

--- a/www/src/contexts/SettingsContext.jsx
+++ b/www/src/contexts/SettingsContext.jsx
@@ -5,7 +5,8 @@ const STORAGE_KEY = 'skywatcher-settings'
 const defaults = {
   observer: { lat: null, lon: null, elev: null, obstructionAngle: 14.2 },
   homeObserver: null,
-  fieldModeEnabled: false,
+  workObserver: null,
+  locationMode: 'home', // 'home' | 'work' | 'field'
   theme: 'auto',
   chartVariant: 'classic',
 }
@@ -16,11 +17,19 @@ function loadSettings() {
     const stored = raw ? JSON.parse(raw) : null
     const settings = { ...defaults, ...(stored ?? {}) }
 
-    // No stored mode preference + Tesla browser → default to field mode
-    const noStoredMode = !stored || stored.fieldModeEnabled === undefined
-    if (noStoredMode && navigator.userAgent.toLowerCase().includes('tesla')) {
-      settings.fieldModeEnabled = true
+    // Back-compat: migrate legacy fieldModeEnabled → locationMode
+    if (stored && stored.locationMode === undefined) {
+      settings.locationMode = stored.fieldModeEnabled === true ? 'field' : 'home'
     }
+
+    // No stored mode preference + Tesla browser → default to field mode
+    const noStoredMode = !stored || stored.locationMode === undefined
+    if (noStoredMode && navigator.userAgent.toLowerCase().includes('tesla')) {
+      settings.locationMode = 'field'
+    }
+
+    // workObserver is never persisted — always hydrated from the server on load
+    settings.workObserver = null
 
     return settings
   } catch {
@@ -34,7 +43,9 @@ export function SettingsProvider({ children }) {
   const [settings, setSettings] = useState(loadSettings)
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+    // Persist everything except workObserver (server-sourced, not user-editable)
+    const { workObserver: _w, ...persistable } = settings
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persistable))
   }, [settings])
 
   useEffect(() => {
@@ -66,8 +77,23 @@ export function SettingsProvider({ children }) {
     })
   }, [])
 
+  // Accept a full work observer object from /api/config. No-ops when null.
+  const updateWorkObserver = useCallback((workObserver) => {
+    setSettings(prev => ({ ...prev, workObserver }))
+  }, [])
+
+  // Derive fieldModeEnabled so existing consumers need no changes
+  const fieldModeEnabled = settings.locationMode === 'field'
+
   return (
-    <SettingsContext.Provider value={{ ...settings, updateSettings, updateObserver, captureHomeObserver }}>
+    <SettingsContext.Provider value={{
+      ...settings,
+      fieldModeEnabled,
+      updateSettings,
+      updateObserver,
+      captureHomeObserver,
+      updateWorkObserver,
+    }}>
       {children}
     </SettingsContext.Provider>
   )


### PR DESCRIPTION
## Summary
- Add Work as a second fixed observer location sourced from server env vars (WORK_LAT/WORK_LON/WORK_ELEV)
- Replace the 2-state Home/Field toggle with a 3-state pill selector: Home | Work | Field
- Work button is disabled when no work location is configured; Field button is hidden when GPS unavailable

## Changes
- `backend/server.js`: expose `workLat/workLon/workElev` from `GET /api/config` when env vars are set
- `contexts/SettingsContext.jsx`: add `workObserver`, `locationMode` ('home'|'work'|'field'); keep `fieldModeEnabled` as derived value for back-compat; migrate existing `fieldModeEnabled:true` localStorage entries to `locationMode:'field'`
- `App.jsx`: 3-state mode selector pill replaces old toggle; observer updated based on locationMode
- `skywatcher.css`: `.mode-selector` styles for 3-state pill (modelled on existing `.chart-toggle`)

Closes #84
Closes #65

## Test plan
- [ ] Without WORK_* env vars: Work button appears but is disabled/dimmed
- [ ] With WORK_* env vars: Work button is active; clicking it switches observer to work location
- [ ] Home returns to server-configured home location
- [ ] Field (if GPS available) continues to use live GPS position
- [ ] Existing users with `fieldModeEnabled:true` in localStorage migrate correctly to Field mode
- [ ] Tesla browser still defaults to Field mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)