### PR TITLE
fix(skychart): remove duplicate rotating wedge (#92/#95 merge artifact)

### DIFF
--- a/www/src/components/SkyChart/SkyChart.jsx
+++ b/www/src/components/SkyChart/SkyChart.jsx
@@ -147,9 +147,6 @@ function ClassicChart({ aircraft, rotation = 0, compassActive = false }) {
         <circle cx={CX} cy={CY} r="3" fill="var(--ink)" />
         <circle cx={CX} cy={CY} r="7" fill="none" stroke="var(--ink)" strokeWidth="0.5" opacity="0.4" />
 
-        {/* Viewing-angle wedge — only when compass is active */}
-        {compassActive && <ViewingWedge cx={CX} cy={CY} r={R} />}
-
         {/* Aircraft: render all, closest (index 0) gets primary accent */}
         {aircraft.map((ac, i) => {
           const [px, py] = azElToXY(ac.az, ac.el, CX, CY, R)
@@ -277,9 +274,6 @@ function DomeChart({ aircraft, rotation = 0, compassActive = false }) {
         {/* Center zenith marker */}
         <circle cx={CX} cy={CY} r="3" fill="var(--ink)" />
         <circle cx={CX} cy={CY} r="7" fill="none" stroke="var(--ink)" strokeWidth="0.5" opacity="0.4" />
-
-        {/* Viewing-angle wedge — only when compass is active */}
-        {compassActive && <ViewingWedge cx={CX} cy={CY} r={R} />}
 
         {/* Aircraft */}
         {aircraft.map((ac, i) => {
@@ -567,9 +561,6 @@ function EmptyChart({ variant, rotation = 0, compassActive = false }) {
 
         {/* Center */}
         <circle cx={CX} cy={CY} r="3" fill="var(--ink)" opacity="0.3" />
-
-        {/* Viewing-angle wedge — only when compass is active */}
-        {compassActive && <ViewingWedge cx={CX} cy={CY} r={R} />}
 
         {/* No aircraft text */}
         <text


### PR DESCRIPTION
## Summary
- PR #92 added `ViewingWedge` inside the rotating `<g>` (the original bug)
- PR #95 added a correct instance outside the rotating `<g>`, but the inner one was already on main and was never removed
- This PR deletes the three inner instances — only the three screen-fixed outer ones remain

## Root Cause
GitHub squash merges produce a diff relative to main at merge time, not relative to the branch base. Since the inner wedge was already on main (from #92), our fix branch's squash diff didn't touch it — it only added the new outer one.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)