### PR TITLE
Fix: restrict aggressive caching to Vite assets

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,7 +36,7 @@ http {
     }
 
     # Versioned assets (content-hashed by Vite) — cache aggressively
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    location ~* ^/assets/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
       expires 30d;
       add_header Cache-Control "public, immutable";
     }

--- a/www/src/components/SkyChart/SkyChart.jsx
+++ b/www/src/components/SkyChart/SkyChart.jsx
@@ -147,9 +147,6 @@ function ClassicChart({ aircraft, rotation = 0, compassActive = false }) {
         <circle cx={CX} cy={CY} r="3" fill="var(--ink)" />
         <circle cx={CX} cy={CY} r="7" fill="none" stroke="var(--ink)" strokeWidth="0.5" opacity="0.4" />
 
-        {/* Viewing-angle wedge — only when compass is active */}
-        {compassActive && <ViewingWedge cx={CX} cy={CY} r={R} />}
-
         {/* Aircraft: render all, closest (index 0) gets primary accent */}
         {aircraft.map((ac, i) => {
           const [px, py] = azElToXY(ac.az, ac.el, CX, CY, R)
@@ -277,9 +274,6 @@ function DomeChart({ aircraft, rotation = 0, compassActive = false }) {
         {/* Center zenith marker */}
         <circle cx={CX} cy={CY} r="3" fill="var(--ink)" />
         <circle cx={CX} cy={CY} r="7" fill="none" stroke="var(--ink)" strokeWidth="0.5" opacity="0.4" />
-
-        {/* Viewing-angle wedge — only when compass is active */}
-        {compassActive && <ViewingWedge cx={CX} cy={CY} r={R} />}
 
         {/* Aircraft */}
         {aircraft.map((ac, i) => {
@@ -567,9 +561,6 @@ function EmptyChart({ variant, rotation = 0, compassActive = false }) {
 
         {/* Center */}
         <circle cx={CX} cy={CY} r="3" fill="var(--ink)" opacity="0.3" />
-
-        {/* Viewing-angle wedge — only when compass is active */}
-        {compassActive && <ViewingWedge cx={CX} cy={CY} r={R} />}
 
         {/* No aircraft text */}
         <text


### PR DESCRIPTION
Restricts aggressive 30-day caching in Nginx to the /assets/ directory. This ensures root-level files like skywatcher.css are always revalidated, fixing issues where updates wouldn't show up without a hard refresh.