### PR TITLE
Feat: Add all visible aircraft to history

### DIFF
--- a/www/src/contexts/AircraftContext.jsx
+++ b/www/src/contexts/AircraftContext.jsx
@@ -15,11 +15,12 @@ export const AircraftContext = createContext({
 export function AircraftProvider({ children }) {
   const [currentAircraft, setCurrentAircraft] = useState(null)
   const [visibleAircraft, setVisibleAircraft] = useState([])
+  const [allAircraft, setAllAircraft] = useState([])
   const [pollingStatus, setPollingStatus] = useState('idle')
   const [enrichment, setEnrichment] = useState(null)
   const [quota, setQuota] = useState(null)
 
-  const { history, addEntry, addEntries } = useHistory()
+  const { history, addEntries } = useHistory()
 
   useEffect(() => { getQuota().then(setQuota) }, [])
 
@@ -63,6 +64,7 @@ export function AircraftProvider({ children }) {
     <AircraftContext.Provider value={{
       currentAircraft, setCurrentAircraft,
       visibleAircraft, setVisibleAircraft,
+      allAircraft, setAllAircraft,
       history,
       pollingStatus, setPollingStatus,
       enrichment,

--- a/www/src/contexts/AircraftContext.jsx
+++ b/www/src/contexts/AircraftContext.jsx
@@ -63,7 +63,6 @@ export function AircraftProvider({ children }) {
     <AircraftContext.Provider value={{
       currentAircraft, setCurrentAircraft,
       visibleAircraft, setVisibleAircraft,
-      allAircraft, setAllAircraft,
       history,
       pollingStatus, setPollingStatus,
       enrichment,

--- a/www/src/contexts/AircraftContext.jsx
+++ b/www/src/contexts/AircraftContext.jsx
@@ -15,19 +15,17 @@ export const AircraftContext = createContext({
 export function AircraftProvider({ children }) {
   const [currentAircraft, setCurrentAircraft] = useState(null)
   const [visibleAircraft, setVisibleAircraft] = useState([])
-  const [allAircraft, setAllAircraft] = useState([])
   const [pollingStatus, setPollingStatus] = useState('idle')
   const [enrichment, setEnrichment] = useState(null)
   const [quota, setQuota] = useState(null)
 
-  const { history, addEntry } = useHistory()
+  const { history, addEntry, addEntries } = useHistory()
 
   useEffect(() => { getQuota().then(setQuota) }, [])
 
   useEffect(() => {
-    if (!currentAircraft) return
-    addEntry(currentAircraft)
-  }, [currentAircraft])
+    addEntries(visibleAircraft)
+  }, [visibleAircraft, addEntries])
 
   const callsign = currentAircraft?.flight?.trim() ?? null
 

--- a/www/src/lib/history.js
+++ b/www/src/lib/history.js
@@ -43,10 +43,17 @@ export function addToHistory(entries, aircraft) {
   const existingIndex = entries.findIndex(e => e.hex === aircraft.hex)
 
   if (existingIndex !== -1) {
+    const existing = entries[existingIndex]
+    const lastSeenTime = new Date(existing.lastSeen).getTime()
+    // Only update if at least 30 seconds have passed to throttle sessionStorage writes
+    if (Date.now() - lastSeenTime < 30_000) {
+      return entries
+    }
+
     // Update lastSeen only, preserve firstSeen and all other fields
     const updated = [...entries]
     updated[existingIndex] = {
-      ...updated[existingIndex],
+      ...existing,
       lastSeen: now,
     }
     return updated

--- a/www/src/lib/history.js
+++ b/www/src/lib/history.js
@@ -67,7 +67,7 @@ export function addToHistory(entries, aircraft) {
 
 /**
  * React hook that manages the observation history, backed by sessionStorage.
- * @returns {{ history: Array, addEntry: (aircraft: Object) => void }}
+ * @returns {{ history: Array, addEntry: (aircraft: Object) => void, addEntries: (aircraftList: Object[]) => void }}
  */
 export function useHistory() {
   const [history, setHistory] = useState(() => loadHistory())
@@ -80,5 +80,17 @@ export function useHistory() {
     })
   }, [])
 
-  return { history, addEntry }
+  const addEntries = useCallback((aircraftList) => {
+    if (!aircraftList || aircraftList.length === 0) return
+    setHistory(prev => {
+      let next = prev
+      for (const ac of aircraftList) {
+        next = addToHistory(next, ac)
+      }
+      if (next !== prev) saveHistory(next)
+      return next
+    })
+  }, [])
+
+  return { history, addEntry, addEntries }
 }


### PR DESCRIPTION
Ensures that all visible aircraft are added to the history bar, not just the closest one. Includes performance optimizations for batch updates and throttling of lastSeen updates to 30-second intervals.