### PR TITLE
Fix: Tesla UA issues (Home Mode & Compass)

### DIFF
--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -108,6 +108,7 @@ function AppShell() {
 
   const orientation = useDeviceOrientation(geo.heading)
   const { heading, permissionState } = orientation
+  const isCompassActive = permissionState === 'granted' || geo.heading != null
 
   useEffect(() => {
     if (!homeObserver) return
@@ -201,7 +202,7 @@ function AppShell() {
                 variant={variant}
                 loading={pollingStatus === 'idle'}
                 rotation={heading}
-                compassActive={permissionState === 'granted'}
+                compassActive={isCompassActive}
               />
             </div>
 
@@ -213,7 +214,7 @@ function AppShell() {
                 </div>
                 <div className="stat-sub">
                   {currentAircraft
-                    ? permissionState === 'granted'
+                    ? isCompassActive
                       ? azToRelative(currentAircraft.az, heading)
                       : azToCardinal(currentAircraft.az)
                     : ''}

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -39,7 +39,12 @@ export default function App() {
             elev: parseFloat(cfg.elev),
             obstructionAngle: parseFloat(cfg.obstructionAngle ?? 14.2),
           })
-          captureHomeObserver()
+          captureHomeObserver({
+            lat: parseFloat(cfg.lat),
+            lon: parseFloat(cfg.lon),
+            elev: parseFloat(cfg.elev),
+            obstructionAngle: parseFloat(cfg.obstructionAngle ?? 14.2),
+          })
         }
 
         if (cfg.workLat && cfg.workLon && cfg.workElev) {
@@ -96,13 +101,13 @@ function elToBand(el) {
 }
 
 function AppShell() {
-  const orientation = useDeviceOrientation()
-  const { heading, permissionState } = orientation
-
   const { visibleAircraft, currentAircraft, setCurrentAircraft, pollingStatus } = useContext(AircraftContext)
   const { chartVariant, updateSettings, updateObserver, locationMode, homeObserver, workObserver } = useContext(SettingsContext)
   const fieldModeEnabled = locationMode === 'field'
   const geo = useGeolocation(fieldModeEnabled)
+
+  const orientation = useDeviceOrientation(geo.heading)
+  const { heading, permissionState } = orientation
 
   useEffect(() => {
     if (!homeObserver) return

--- a/www/src/contexts/SettingsContext.jsx
+++ b/www/src/contexts/SettingsContext.jsx
@@ -69,9 +69,12 @@ export function SettingsProvider({ children }) {
   }, [])
 
   // Set once on initial server sync — never overwritten after that.
-  const captureHomeObserver = useCallback(() => {
+  const captureHomeObserver = useCallback((explicitHome = null) => {
     setSettings(prev => {
       if (prev.homeObserver !== null) return prev
+      if (explicitHome && explicitHome.lat !== null) {
+        return { ...prev, homeObserver: { ...explicitHome } }
+      }
       if (prev.observer.lat === null) return prev
       return { ...prev, homeObserver: { ...prev.observer } }
     })

--- a/www/src/lib/geolocation.js
+++ b/www/src/lib/geolocation.js
@@ -9,7 +9,7 @@ export const GEOLOCATION_FAILURE_THRESHOLD = 2
  * React hook for live geolocation with retry logic and permission tracking.
  *
  * @param {boolean} enabled  Enable/disable geolocation polling.
- * @returns {{ position: {lat,lon,accuracy}|null, isSupported: boolean,
+ * @returns {{ position: {lat,lon,accuracy}|null, heading: number|null, isSupported: boolean,
  *   isDenied: boolean, consecutiveFailures: number, error: string|null }}
  *
  * Polling interval: 3s. Permission-denied retry: [500ms, 1000ms] backoff.
@@ -20,6 +20,7 @@ export function useGeolocation(enabled) {
   const isSupported = typeof navigator !== 'undefined' && 'geolocation' in navigator
 
   const [position, setPosition] = useState(null)
+  const [heading, setHeading] = useState(null)
   const [isDenied, setIsDenied] = useState(false)
   const [error, setError] = useState(null)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
@@ -51,6 +52,7 @@ export function useGeolocation(enabled) {
         lon: pos.coords.longitude,
         accuracy: pos.coords.accuracy,
       })
+      setHeading(pos.coords.heading)
     }
 
     function handleError(err) {
@@ -92,6 +94,7 @@ export function useGeolocation(enabled) {
 
   return {
     position,
+    heading,
     isSupported,
     isDenied,
     consecutiveFailures,

--- a/www/src/lib/orientation.js
+++ b/www/src/lib/orientation.js
@@ -3,9 +3,10 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 /**
  * React hook to access device orientation (compass heading).
  * Handles iOS permission request logic and Android 'absolute' orientation.
+ * Accepts `gpsHeading` as a fallback when native orientation is unavailable.
  */
-export function useDeviceOrientation() {
-  const [heading, setHeading] = useState(0)
+export function useDeviceOrientation(gpsHeading = null) {
+  const [nativeHeading, setNativeHeading] = useState(0)
   const [isSupported, setIsSupported] = useState(false)
   const [permissionState, setPermissionState] = useState('unknown') // 'unknown' | 'granted' | 'denied'
 
@@ -27,7 +28,7 @@ export function useDeviceOrientation() {
         const delta = ((correctedHeading - smoothedHeadingRef.current + 540) % 360) - 180
         smoothedHeadingRef.current = (smoothedHeadingRef.current + ALPHA * delta + 360) % 360
       }
-      setHeading(smoothedHeadingRef.current)
+      setNativeHeading(smoothedHeadingRef.current)
     }
   }, [])
 
@@ -92,6 +93,8 @@ export function useDeviceOrientation() {
       }
     }
   }, [])
+
+  const heading = permissionState === 'granted' ? nativeHeading : (gpsHeading ?? 0)
 
   return { heading, isSupported, permissionState, requestPermission }
 }


### PR DESCRIPTION
Resolves #107 and #108. 

**Changes:**
1. **Home Mode Race Condition:** On Tesla browsers, the app defaults to Field Mode, activating GPS immediately. If GPS resolved before the API config returned,  was set by GPS, causing  to be skipped. This PR updates  to accept an explicit config object and ensures it's always called when the API returns. Also added a guard to wait for  before applying GPS updates.
2. **GPS Heading Support:** Tesla's browser doesn't expose gyroscope events (). This PR updates  to expose GPS  and uses it as a fallback in  to enable the compass feature on Tesla vehicles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced device orientation tracking with GPS heading as fallback when device orientation permission is unavailable
  * Improved initialization of location-based settings with explicit geolocation parameters
  * More accurate compass readings across different permission scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->